### PR TITLE
Added code to ensure ilogb is not declared when running on mac

### DIFF
--- a/driver.cpp
+++ b/driver.cpp
@@ -63,7 +63,9 @@
 #endif
 
 
-extern int ilogb(double) throw();
+#if not __APPLE__
+	extern int ilogb(double) throw();
+#endif
 
 //for counting numbers of calls to std::partial_sort
 #define PARTIAL_SORT_COUNT


### PR DESCRIPTION
Hello, 

I attempted to run your code on mac (El Capitan) using your Make file, however I had issues with Clang due to the declaration of the ilogb method. 

In order for your code to work "out of the box" on mac, I simply added a conditional so the ilogb method is not declared on the mac operating system.

Additionally, I have tested this on Linux Ubuntu 16.04 where it seemed to work nicely as well. 
