### PR TITLE
Dual pivot blockquicksort

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,58 @@ This package consists of the following files:
 	make <algorithm>.comp
 	make <algorithm>.move
   These tests are not implemented for all algorithms.
+
+
+
+# How to build single programs
+Build a single algorithm can be done through: 
+```
+	make build ALGNAME="algorithm_name"
+```
+
+Build a single algorithm with a custom type: 
+```
+	make build ALGNAME="algorithm_name" TYPE="custom_type"	
+```
+
+#How to run
+## Run single programs
+```
+	./a.out input_size distribution_type seed
+```
+distribution_type is given by 1 letter, see driver.cpp for further details, 
+it has quite a few!. 
+
+## Run tests
+There are quite a few testing methods, I encourage you to go exploring yourself, however 
+the most notable are listed below. 
+
+
+### newtimetest
+Runs all algorithms with the permutations defined in the variable: newsmalldata. 
+We tested with the variable existingsmalldata
+
+```
+make newtimetest
+```
+
+### timetest
+Existing method we do not implement. 
+Runs a lot of tests with different types and permutations, takes a while!
+```
+make timetest
+```
+
+### perftimetest
+Runs the perf state command on all algorithms, on all input sizes with random permutation.
+Used to see instructions count, branches and branch misses. 
+
+```
+make perftimetest
+```
+
+### newblocksizetest
+Runs blocksize tests on both blocked and multi-pivot blocked algorithms.
+```
+make newblocksizetest
+```

--- a/median.h
+++ b/median.h
@@ -52,10 +52,9 @@ namespace median {
 		sort_pair(begin, mid, less);
 		return mid;
 	}
-
 	
 	template<typename iter, typename Compare>
-	inline iter* mp_median_of_3_pivots_2(iter begin, iter end, Compare less){
+	inline iter* mp_tertiles_of_3_pivots_2(iter begin, iter end, Compare less){
 		int tmp = (end-begin)/4;
 		iter sek1 = begin+tmp;
 		iter sek2 = begin+(2*tmp);
@@ -74,10 +73,8 @@ namespace median {
 		ret[1] = sek3; 
 		return ret;
 	}
-
 	template<typename iter, typename Compare>
-	inline iter* mp_median_of_5_pivots_2(iter begin, iter end, Compare less){
-//		std::cout << "median length: " << (end-begin) << std::endl;
+	inline iter* mp_tertiles_of_5_pivots_2(iter begin, iter end, Compare less){
 		int tmp = (end-begin)/6;
 		iter sek1 = begin+tmp;
 		iter sek2 = begin+(2*tmp);

--- a/median.h
+++ b/median.h
@@ -5,7 +5,7 @@
 *
 ******************************************************************************
 * Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
-* Copyright (C) 2016 Armin Weiß <armin.weiss@fmi.uni-stuttgart.de>
+* Copyright (C) 2016 Armin Weiï¿½ <armin.weiss@fmi.uni-stuttgart.de>
 *
 * This program is free software: you can redistribute it and/or modify it
 * under the terms of the GNU General Public License as published by the Free
@@ -51,6 +51,54 @@ namespace median {
 		sort_pair(mid, end - 1, less);
 		sort_pair(begin, mid, less);
 		return mid;
+	}
+
+	
+	template<typename iter, typename Compare>
+	inline iter* mp_median_of_3_pivots_2(iter begin, iter end, Compare less){
+		int tmp = (end-begin)/4;
+		iter sek1 = begin+tmp;
+		iter sek2 = begin+(2*tmp);
+		iter sek3 = begin+(3*tmp);
+		sort_pair(begin, sek1, less);
+		sort_pair(sek3, end, less);
+		sort_pair(sek2, end, less);
+		sort_pair(sek2, sek3, less);
+		sort_pair(begin, sek3, less);
+		sort_pair(begin, sek2, less);
+		sort_pair(sek1, end, less);
+		sort_pair(sek1, sek3, less);
+		sort_pair(sek1, sek2, less);
+		iter* ret = new iter[2];
+		ret[0] = sek1;
+		ret[1] = sek3; 
+		return ret;
+	}
+
+	template<typename iter, typename Compare>
+	inline iter* mp_median_of_5_pivots_2(iter begin, iter end, Compare less){
+//		std::cout << "median length: " << (end-begin) << std::endl;
+		int tmp = (end-begin)/6;
+		iter sek1 = begin+tmp;
+		iter sek2 = begin+(2*tmp);
+		iter sek3 = begin+(3*tmp);
+		iter sek4 = begin+(4*tmp);
+		iter sek5 = begin+(5*tmp);
+
+		sort_pair(sek1, sek2, less);
+		sort_pair(sek4, sek5, less);
+		sort_pair(sek3, sek5, less);
+		sort_pair(sek3, sek4, less);
+		sort_pair(sek1, sek4, less);	
+		sort_pair(sek1, sek3, less);
+		sort_pair(sek2, sek5, less);
+		sort_pair(sek2, sek4, less);
+		sort_pair(sek2, sek3, less);
+		assert(sek2 != sek4);
+		iter* ret = new iter[2];
+		ret[0] = sek2;
+		ret[1] = sek4; 
+		return ret;
 	}
 
 	template<typename iter, typename Compare>

--- a/multi_pivot_2_blocked.h++
+++ b/multi_pivot_2_blocked.h++
@@ -1,0 +1,55 @@
+/******************************************************************************
+* blocked.h++
+*
+* interface for BlockQuicksort with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace multi_pivot_2_blocked {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Multi_Pivot_Hoare_Block_partition_simple>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Multi_Pivot_Hoare_Block_partition_simple>(begin, end, std::less<T>());
+	}
+}

--- a/multi_pivot_2_blocked_equal.h++
+++ b/multi_pivot_2_blocked_equal.h++
@@ -1,0 +1,55 @@
+/******************************************************************************
+* blocked.h++
+*
+* interface for BlockQuicksort with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace multi_pivot_2_blocked_equal {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot_equal_elements<partition::Multi_Pivot_Hoare_Block_partition_simple>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot_equal_elements<partition::Multi_Pivot_Hoare_Block_partition_simple>(begin, end, std::less<T>());
+	}
+}

--- a/multi_pivot_2_blocked_equal_thousand.h++
+++ b/multi_pivot_2_blocked_equal_thousand.h++
@@ -1,0 +1,55 @@
+/******************************************************************************
+* blocked.h++
+*
+* interface for BlockQuicksort with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace multi_pivot_2_blocked_equal_thousand {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot_equal_elements_thousand<partition::Multi_Pivot_Hoare_Block_partition_simple>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot_equal_elements_thousand<partition::Multi_Pivot_Hoare_Block_partition_simple>(begin, end, std::less<T>());
+	}
+}

--- a/multi_pivot_2_blocked_mo_5.h++
+++ b/multi_pivot_2_blocked_mo_5.h++
@@ -1,0 +1,55 @@
+/******************************************************************************
+* blocked.h++
+*
+* interface for BlockQuicksort with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace multi_pivot_2_blocked_mo_5 {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Multi_Pivot_Hoare_Block_partition_simple_mo5>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Multi_Pivot_Hoare_Block_partition_simple_mo5>(begin, end, std::less<T>());
+	}
+}

--- a/multi_pivot_2_blocked_mo_5_equal.h++
+++ b/multi_pivot_2_blocked_mo_5_equal.h++
@@ -1,0 +1,55 @@
+/******************************************************************************
+* blocked.h++
+*
+* interface for BlockQuicksort with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace multi_pivot_2_blocked_mo_5_equal {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot_equal_elements<partition::Multi_Pivot_Hoare_Block_partition_simple_mo5>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot_equal_elements<partition::Multi_Pivot_Hoare_Block_partition_simple_mo5>(begin, end, std::less<T>());
+	}
+}

--- a/multi_pivot_2_blocked_mo_5_equal_thousand.h++
+++ b/multi_pivot_2_blocked_mo_5_equal_thousand.h++
@@ -1,0 +1,55 @@
+/******************************************************************************
+* blocked.h++
+*
+* interface for BlockQuicksort with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace multi_pivot_2_blocked_mo_5_equal_thousand {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot_equal_elements_thousand<partition::Multi_Pivot_Hoare_Block_partition_simple_mo5>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot_equal_elements_thousand<partition::Multi_Pivot_Hoare_Block_partition_simple_mo5>(begin, end, std::less<T>());
+	}
+}

--- a/multi_pivot_2_blocked_mo_5_thousand.h++
+++ b/multi_pivot_2_blocked_mo_5_thousand.h++
@@ -1,0 +1,55 @@
+/******************************************************************************
+* blocked.h++
+*
+* interface for BlockQuicksort with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace multi_pivot_2_blocked_mo_5_thousand {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot_thousand<partition::Multi_Pivot_Hoare_Block_partition_simple_mo5>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot_thousand<partition::Multi_Pivot_Hoare_Block_partition_simple_mo5>(begin, end, std::less<T>());
+	}
+}

--- a/multi_pivot_2_blocked_thousand.h++
+++ b/multi_pivot_2_blocked_thousand.h++
@@ -1,0 +1,55 @@
+/******************************************************************************
+* blocked.h++
+*
+* interface for BlockQuicksort with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace multi_pivot_2_blocked_thousand {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot_thousand<partition::Multi_Pivot_Hoare_Block_partition_simple>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot_thousand<partition::Multi_Pivot_Hoare_Block_partition_simple>(begin, end, std::less<T>());
+	}
+}

--- a/partition.h
+++ b/partition.h
@@ -7,7 +7,7 @@
 *
 ******************************************************************************
 * Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
-* Copyright (C) 2016 Armin Weiß <armin.weiss@fmi.uni-stuttgart.de>
+* Copyright (C) 2016 Armin Weiï¿½ <armin.weiss@fmi.uni-stuttgart.de>
 *
 * This program is free software: you can redistribute it and/or modify it
 * under the terms of the GNU General Public License as published by the Free
@@ -36,7 +36,7 @@
 #include <cmath>
 #include <assert.h>
 #include <functional>
-
+#include "rotations.h"
 //#defineMOREPARTITIONERS
 #ifndef BLOCKSIZE
 #define BLOCKSIZE 128
@@ -151,7 +151,7 @@ namespace partition {
 
 		}//end main loop
 
-		 //Compare and store in buffers final iteration
+		//Compare and store in buffers final iteration
 		index shiftR = 0, shiftL = 0;
 		if (num_right == 0 && num_left == 0) {	//for small arrays or in the unlikely case that both buffers are empty
 			shiftL = ((last - begin) + 1) / 2;
@@ -1064,5 +1064,368 @@ namespace partition {
 		}
 	};
 
+	template<typename iter>
+	void printArray(iter begin, iter end,  const std::string &desc) {
+		int i = 0;
 
+		if((end - begin) < 0) {
+			std::cout << desc << " printing failed because begin was above end" << std::endl;
+			return;
+		}
+		iter begin2 = begin;
+		iter end2 = end;
+		std::cout << "Printing array: " << desc << std::endl;
+		while (begin2 != end2) {
+			
+			std::cout << *begin2 << " ";
+			begin2++;
+			i++;
+			
+		}
+		std::cout << std::endl;
+
+	}
+
+	template<typename iter, typename Compare>
+	inline void multi_pivot_2_block_partition_simple(iter begin, iter end, iter* pivot_positions, Compare less, iter* ret1, iter* ret2) {
+		typedef typename std::iterator_traits<iter>::difference_type index;		
+		int block = 2 * BLOCKSIZE;
+
+		index R[block], L[block];
+
+		iter last = end-1;
+		//Moving pivots to the last positions
+		std::iter_swap(pivot_positions[0], begin);
+		std::iter_swap(pivot_positions[1], last);
+		const typename std::iterator_traits<iter>::value_type & p1 = *begin;
+		const typename std::iterator_traits<iter>::value_type & p2 = *last;
+		pivot_positions[0] = begin;
+		pivot_positions[1] = last;
+		last--;
+		begin++;
+
+		int num_ll = 0;
+		int num_lr = 0;
+		int num_rl = 0;
+		int num_rr = 0;
+		iter middle = begin;
+		int delta = BLOCKSIZE;
+		int start_ll = 0;
+		int start_lr = 0;
+		int start_rl = 0;
+		int start_rr = 0;
+		int num;
+		index i, j;
+		while (last - begin + 1 > 2 * BLOCKSIZE) {
+			if(num_ll == 0 && num_lr == 0) {
+				start_ll = 0;
+				start_lr = 0;
+				for (i = 0; i < BLOCKSIZE; i++) {
+					L[num_ll] = i;
+					L[delta + num_lr] = i;
+
+					//Is it in the right partition
+					num_lr += less(p2, begin[i]);
+					//Is it in the left partition
+					num_ll += less(begin[i], p1);
+				}
+			}
+
+			if(num_rl == 0 && num_rr == 0) {
+				start_rl = 0;
+				start_rr = 0;
+				for (j = 0; j < BLOCKSIZE; j++) {
+					R[num_rl] = j;
+					R[delta + num_rr] = j;
+					
+					//Current index
+					auto leftIndex = (last - j);
+					//Is it in the left partition
+					int b1 = (less(*leftIndex, p1));
+					num_rl += b1;
+					//Is it in the middle partition
+					num_rr += (!b1 && !less(p2, *leftIndex));
+				}
+			}
+
+			//Rearrange the elements
+			//Swap lr with rr
+			
+			num = std::min(num_lr, num_rr);
+			for (int k = 0; k < num; k++) {
+				std::iter_swap(begin + L[start_lr + delta + k], last-R[start_rr + delta + k]);
+			}
+			start_lr += num;
+			start_rr += num;
+			num_lr -= num;
+			num_rr -= num;
+
+			//Edge case where we have empty LL elements that are already in place
+			
+			if(middle == begin) {
+				int ll = 0;
+				while (*(L + start_ll) == ll && num_ll > 0 ){
+					++start_ll;
+					--num_ll;
+					++ll;
+					middle++;
+				}
+			}
+
+			//lr <-> rl
+			num = std::min(num_lr, num_rl);
+			for (int k = 0; k < num; k++) {
+				//Ensuring our middle partition is large enough
+				while (*(L + start_ll) < *(L + start_lr + delta + k) && num_ll > 0) {
+					std::iter_swap(middle, begin + L[start_ll]);
+					++start_ll;
+					--num_ll;
+					++middle;
+				}
+				rotations::rotate3(*(begin + L[start_lr + delta + k]), *middle, *(last - R[start_rl + k]));
+				middle++;
+			} 
+			
+			start_rl += num;
+			start_lr += num;
+			num_rl -= num;
+			num_lr -= num;
+			
+			//Empty ll
+			if(num_lr == 0) { 
+				for(int k = 0; k < num_ll; k++) {
+					std::iter_swap(begin + L[start_ll + k], middle);
+					middle++;
+				}
+				start_ll += num_ll;
+				num_ll = 0;
+			}		
+
+			begin += (num_ll == 0 && num_lr == 0) ? BLOCKSIZE : 0;
+			last -= (num_rl == 0 && num_rr == 0) ? BLOCKSIZE : 0;
+		}
+		
+		//Compare and store in buffers final iteration
+		index shiftR = 0;
+		index shiftL = 0;
+		if(num_ll == 0 && num_lr == 0 && num_rl == 0 && num_rr == 0) {
+			shiftL = ((last-begin) + 1) / 2; 
+			shiftR = (last - begin) + 1 - shiftL;
+			start_ll = 0;
+			start_lr = 0;
+			start_rr = 0;
+			start_rl = 0;
+			for (index j = 0; j < shiftL; j++) {
+				L[num_ll] = j;
+				L[delta + num_lr] = j;
+				//Is it in the right partition
+				num_lr += less(p2, begin[j]);
+				//Is it in the left partition
+				num_ll += less(begin[j], p1);
+				R[num_rl] = j;
+				R[delta + num_rr] = j;
+				
+				//Current index
+				auto leftIndex = (last - j);
+				//Is it in the left partition
+				int b1 = (less(*leftIndex, p1));
+				num_rl += b1;
+				//Is it in the middle partition
+				num_rr += (!b1 && !(less(p2, *leftIndex)));
+			}
+			
+			if(shiftL < shiftR) {
+				auto subIndex = (last - shiftR + 1);
+				int b1 = (less(*subIndex, p1));
+				R[num_rl] = shiftR - 1;
+				R[delta + num_rr] = shiftR - 1;
+				num_rl += b1;
+				num_rr += !b1 && !less(p2, *subIndex);
+			}
+		}
+		else if(num_rl != 0 || num_rr != 0) {
+			shiftL = (last - begin) - BLOCKSIZE + 1;
+			shiftR = BLOCKSIZE;
+			start_ll = 0;
+			start_lr = 0;
+			for(index j = 0; j < shiftL; j++) {
+				L[num_ll] = j;
+				L[delta + num_lr] = j;
+				num_ll += (less(begin[j], p1));
+				num_lr += less(p2, begin[j]);
+			}
+		} else {
+			shiftL = BLOCKSIZE;
+			shiftR = (last - begin) - BLOCKSIZE + 1;
+			start_rl = 0;
+			start_rr = 0;
+			for (index j = 0; j < shiftR; j++) {
+				R[num_rl] = j;
+				R[delta + num_rr] = j;
+				bool b1 = less(*(last-j), p1);
+				num_rl += b1;
+				num_rr += !b1 && !less(p2, *(last-j));
+			}
+		}
+
+		//rearrange final iteration
+		//Swap lr with rr
+		num = std::min(num_lr, num_rr);
+		for (int k = 0; k < num; k++) {
+			std::iter_swap(begin + L[start_lr + delta + k], last-R[start_rr + delta + k]);
+		}
+		start_lr += num;
+		start_rr += num;
+		num_lr -= num;
+		num_rr -= num;
+
+		//Edge case where we have empty LL elements that are already in place
+		int ll = 0;
+		if(middle == begin) {
+			while (*(L + start_ll) == ll && num_ll > 0 ){
+				++start_ll;
+				--num_ll;
+				++ll;
+				middle++;
+			}
+		}
+
+		//lr <-> rl
+		num = std::min(num_lr, num_rl);
+		for (int k = 0; k < num; k++) {
+			//Ensuring our middle partition is large enough
+			while (*(L + start_ll) < *(L + start_lr + delta + k) && num_ll > 0) {
+				std::iter_swap(middle, begin + L[start_ll]);
+				++start_ll;
+				--num_ll;
+				++middle;
+			}
+			rotations::rotate3(*(begin + L[start_lr + delta + k]), *middle, *(last - R[start_rl + k]));
+			middle++;
+		} 
+		
+		start_rl += num;
+		start_lr += num;
+		num_rl -= num;
+		num_lr -= num;
+		
+		//Empty ll
+		if(num_lr == 0) { 
+			for(int k = 0; k < num_ll; k++) {
+				std::iter_swap(begin + L[start_ll + k], middle);
+				middle++;
+			}
+			start_ll += num_ll;
+			num_ll = 0;
+		}		
+
+		begin += (num_ll == 0 && num_lr == 0) ? shiftL : 0;
+		last -= (num_rl == 0 && num_rr == 0) ? shiftR : 0;
+		
+		iter right = last+1;
+		
+		int k = 0;
+		int l = last - begin;
+		//TODO: More elegant way of detecting this?
+		bool rightLoop = num_rl != 0 || num_rr != 0;
+		
+		//If left side is empty, and right side as elements	
+		while(num_rl != 0 || num_rr != 0){
+			//search from left to right 
+			while((( num_rr != 0 && l == R[start_rr + delta + num_rr - 1] ) || (num_rl != 0 && l == R[start_rl + num_rl - 1])) && l > k ){
+				bool b = num_rl != 0 && (l == R[start_rl + num_rl - 1]); // 1 if left 
+				std::iter_swap(last - l, middle);
+				middle += b;
+				num_rr -= !b;
+				num_rl -= b;
+				l--;
+			}
+			
+			//search from right to left
+			while((num_rr == 0 || k != R[delta + start_rr]) && (num_rl == 0 || k != R[start_rl]) && l > k) 
+			{  
+				k++;
+			}
+			
+			bool mid = num_rr != 0 && k == R[delta + start_rr]; //Is 1 if element is a mid element, false no mid elements
+			bool left = num_rl != 0 && k == R[start_rl]; 
+			//Rotate last middle begin or last begin begin
+			rotations::rotate3(*(last - k) , *(last - l),   *((last - l) - (left * ((last - l) - middle))));
+			
+			l -= l > k;
+			k += l > k;	
+			middle += left;
+			start_rl += left;
+			num_rl -= left;
+			num_rr -= mid;
+			start_rr += mid;
+			assert(num_rr > -1); assert(num_rl > -1);
+		}
+		
+		
+		//If we executed the right loop and emptied the blocks we cannot 
+		//guarantee that the right pointer was moved all the way so we just move it by
+		//the difference between k and l.
+		if(rightLoop)
+			right = (last - l + (*(last - l) < p2)); //TODO: Can there be a more elegant way?
+
+		//Should ensure the edge case of middle being ahead of begin
+		k += middle - (begin + k);
+
+		//If right side is empty and left side has elements
+		while(num_ll != 0 || num_lr != 0) {
+
+			while(((num_lr != 0 && k != L[start_lr + delta]) || (num_ll != 0 && num_lr == 0)) && l > k) {
+				bool b = num_ll != 0 && (k == L[start_ll]);	
+				std::iter_swap(begin + k,  middle);	
+				middle += b;
+				num_ll -= b;
+				start_ll += b;
+				k++;
+			}
+
+
+			while( num_lr != 0 && l == L[start_lr + num_lr + delta - 1] && l > 0 && l > k) {
+				num_lr--;
+				l--;
+				right--;
+			}
+			bool b = num_ll != 0 && (l == L[start_ll + num_ll - 1]);
+			//Rotate last middle begin or last begin begin
+			rotations::rotate3(*(begin + l), *(begin + k), *((begin + k) - (b * ((begin + k) - middle))));
+			middle += b;
+			num_ll -= b;
+			
+			bool isRight = num_lr != 0;
+			num_lr -= isRight;
+			start_lr += isRight;
+			
+			l--;
+			k++;
+			right -= isRight;
+			assert(num_lr > -1); assert(num_ll > -1);
+		}
+
+		std::iter_swap(pivot_positions[0], middle - 1);
+		std::iter_swap(pivot_positions[1], right);
+		*ret1 = (middle - 1);
+		*ret2 = right;
+	}
+
+	//Multi-Pivot part 
+	template< typename iter, typename Compare>
+	struct Multi_Pivot_Hoare_Block_partition_simple {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_median_of_3_pivots_2(begin, end-1, less);
+			multi_pivot_2_block_partition_simple(begin, end, pivots, less, p1, p2);
+		}
+	};
+
+	template< typename iter, typename Compare>
+	struct Multi_Pivot_Hoare_Block_partition_simple_mo5 {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_median_of_5_pivots_2(begin, end-1, less);
+			multi_pivot_2_block_partition_simple(begin, end, pivots, less, p1, p2);
+		}
+	};	
 };

--- a/partition.h
+++ b/partition.h
@@ -1416,7 +1416,7 @@ namespace partition {
 	template< typename iter, typename Compare>
 	struct Multi_Pivot_Hoare_Block_partition_simple {
 		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
-			iter* pivots = median::mp_median_of_3_pivots_2(begin, end-1, less);
+			iter* pivots = median::mp_tertiles_of_3_pivots_2(begin, end-1, less);
 			multi_pivot_2_block_partition_simple(begin, end, pivots, less, p1, p2);
 		}
 	};
@@ -1424,7 +1424,7 @@ namespace partition {
 	template< typename iter, typename Compare>
 	struct Multi_Pivot_Hoare_Block_partition_simple_mo5 {
 		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
-			iter* pivots = median::mp_median_of_5_pivots_2(begin, end-1, less);
+			iter* pivots = median::mp_tertiles_of_5_pivots_2(begin, end-1, less);
 			multi_pivot_2_block_partition_simple(begin, end, pivots, less, p1, p2);
 		}
 	};	

--- a/quicksort.h
+++ b/quicksort.h
@@ -5,7 +5,7 @@
 *
 ******************************************************************************
 * Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
-* Copyright (C) 2016 Armin Weiß <armin.weiss@fmi.uni-stuttgart.de>
+* Copyright (C) 2016 Armin Weiï¿½ <armin.weiss@fmi.uni-stuttgart.de>
 *
 * This program is free software: you can redistribute it and/or modify it
 * under the terms of the GNU General Public License as published by the Free
@@ -25,7 +25,7 @@
 #include <future>
 #include <cstdlib>
 #ifndef IS_THRESH
-#define IS_THRESH (1<<4)
+#define IS_THRESH 20 //(1 << 4)
 #endif // !IS_THRESH
 
 
@@ -169,5 +169,406 @@ namespace quicksort {
 			}
 		} while (s != stack);
 	}
+
+	//main Multi-Pivot Quicksort loop NOT supporting Partitioner with check for duplicate elements
+	//Implementation based on Tuned Quicksort (Elmasry, Katajainen, Stenmark)
+	//available at http://www.diku.dk/~jyrki/Myris/Kat2014S.html
+	template<template<class , class> class Partitioner, typename iter, typename Compare>
+	inline void qsort_dual_pivot(iter begin, iter end, Compare less) {
+		const int depth_limit = 2 * ilogb((double)(end - begin)) + 3;
+		iter stack[80];
+		iter* s = stack;
+		int depth_stack[80];
+		int depth = 0;
+		int* d_s_top = depth_stack;
+		*s = begin;
+		*(s + 1) = end;
+		s += 2;
+		*d_s_top = 0;
+		++d_s_top;
+		do {
+			assert((end >= begin));
+			if (depth < depth_limit && (end - begin > IS_THRESH)) {
+				iter p1;
+				iter p2;
+				
+				Partitioner<iter, Compare>::partition(begin, end, &p1, &p2, less);
+				
+				assert((p1 < p2));
+				assert(p2 < end);
+				int part1 = p1 - begin;
+				int part2 = p2 - p1;
+				int part3 = end - p2;
+				if (part2 > part1 && part3 > part1) { //Partition 1 is the smallest
+					*s = p1 + 1;
+					*(s + 1) = p2;
+					*(s + 2) = p2 + 1;
+					*(s + 3) = end;
+					end = p1;
+				}
+				else if(part1 > part2 && part3 > part2) { //Partition 2 is the smallest
+					*s = begin;
+					*(s + 1) = p1;
+					*(s + 2) = p2 + 1;
+					*(s + 3) = end;
+					begin = p1 + 1;
+					end = p2;
+				}
+				else {
+					*s = begin;
+					*(s + 1) = p1;
+					*(s + 2) = p1 + 1;
+					*(s + 3) = p2;
+					begin = p2 + 1;
+				}
+				assert(begin <= end);
+				s += 4;
+				*d_s_top = ++depth;
+				*(d_s_top+1) = ++depth;
+				d_s_top += 2;
+
+			}
+			else {
+				
+				if (end - begin > IS_THRESH) { // if recursion depth limit exceeded
+#ifdef PARTIAL_SORT_COUNT
+					partial_sort_count++;
+#endif
+					std::partial_sort(begin, end, end);
+				}
+#ifndef NOINSERTIONSORT
+				else {
+					insertionsort::insertion_sort(begin, end, less); // copy of std::__insertion_sort (GCC 4.7.2)
+				}
+#endif 			
+				//pop new subarray from stack
+				s -= 2;
+				begin = *s;
+				end = *(s + 1);
+				--d_s_top;
+				assert(d_s_top != (depth_stack-1));
+				depth = *d_s_top;
+				assert(begin <= end);
+			}
+		} while (s != stack);
+	}
+
+
+	template<template<class , class> class Partitioner, typename iter, typename Compare>
+	inline void qsort_dual_pivot_equal_elements(iter begin, iter end, Compare less) {
+		const int depth_limit = 2 * ilogb((double)(end - begin)) + 3;
+		iter stack[80];
+		iter* s = stack;
+		int depth_stack[80];
+		int depth = 0;
+		int* d_s_top = depth_stack;
+		*s = begin;
+		*(s + 1) = end;
+		s += 2;
+		*d_s_top = 0;
+		++d_s_top;
+		do {
+			assert((end >= begin));
+			if (depth < depth_limit && (end - begin > IS_THRESH)) {
+				iter p1;
+				iter p2;
+				
+				Partitioner<iter, Compare>::partition(begin, end, &p1, &p2, less);
+				
+				if(*p1 == *p2){
+					//Disregard the middle partition
+					//search, we remove all the elements equal to the pivot
+					int part1 = p1 - begin;
+					//int part2 = p2 - p1;
+					int part3 = end - p2;
+					if (part1 > part3) {
+						*s = begin;
+						*(s + 1) = p1;
+						begin = p2 + 1;
+					}
+					else {
+						*s = p2 + 1; 
+						*(s + 1) = end;
+						end = p1;
+					}
+
+					s += 2;
+					depth++;
+					*d_s_top = depth;
+					++d_s_top;
+
+				}
+				else{
+					//Attempt at making things smaller
+					//Search, we remove all the elements equal to the pivot
+					iter tmp2 = p2;
+					while(*p2 == *(tmp2-1) && less(*p1, *(tmp2-1))) 
+						tmp2--;
+
+					//Search in the middle
+					iter tmp1 = p1;
+					while(*p1 == *(tmp1+1) && less(*(tmp1+1), *end))
+						tmp1++;
+					
+					int part1 = p1 - begin;
+					int part2 = tmp2 - tmp1;
+					int part3 = end - p2;
+
+					if (part2 > part1 && part3 > part1) { //Partition 1 is the smallest
+						*s = tmp1 + 1;
+						*(s + 1) = tmp2;
+						*(s + 2) = p2 + 1;
+						*(s + 3) = end;
+						end = p1;
+					}
+					else if(part1 > part2 && part3 > part2) { //Partition 2 is the smallest
+						*s = begin;
+						*(s + 1) = p1;
+						*(s + 2) = p2 + 1;
+						*(s + 3) = end;
+						begin = tmp1 + 1;
+						end = tmp2;
+					}
+					else {
+						*s = begin;
+						*(s + 1) = p1;
+						*(s + 2) = tmp1 + 1;
+						*(s + 3) = tmp2;
+						begin = p2 + 1;
+					}
+					assert(begin <= end);
+					s += 4;
+					*d_s_top = ++depth;
+					*(d_s_top+1) = ++depth;
+					d_s_top += 2;
+				}
+				
+
+			}
+			else {
+				
+				if (end - begin > IS_THRESH) { // if recursion depth limit exceeded
+#ifdef PARTIAL_SORT_COUNT
+					partial_sort_count++;
+#endif
+					std::partial_sort(begin, end, end);
+				}
+#ifndef NOINSERTIONSORT
+				else {
+					insertionsort::insertion_sort(begin, end, less); // copy of std::__insertion_sort (GCC 4.7.2)
+				}
+#endif 			
+				//pop new subarray from stack
+				s -= 2;
+				begin = *s;
+				end = *(s + 1);
+				--d_s_top;
+				assert(d_s_top != (depth_stack-1));
+				depth = *d_s_top;
+				assert(begin <= end);
+			}
+		} while (s != stack);
+	}
+
+
+	//main Multi-Pivot Quicksort loop NOT supporting Partitioner with check for duplicate elements
+	//Implementation based on Tuned Quicksort (Elmasry, Katajainen, Stenmark)
+	//available at http://www.diku.dk/~jyrki/Myris/Kat2014S.html
+	template<template<class , class> class Partitioner, typename iter, typename Compare>
+	inline void qsort_dual_pivot_thousand(iter begin, iter end, Compare less) {
+		const int depth_limit = 2 * ilogb((double)(end - begin)) + 3;
+		iter stack[80];
+		iter* s = stack;
+		int depth_stack[80];
+		int depth = 0;
+		int* d_s_top = depth_stack;
+		*s = begin;
+		*(s + 1) = end;
+		s += 2;
+		*d_s_top = 0;
+		++d_s_top;
+		do {
+			assert((end >= begin));
+			if (depth < depth_limit && (end - begin > 1000)) {
+				iter p1;
+				iter p2;
+				
+				Partitioner<iter, Compare>::partition(begin, end, &p1, &p2, less);
+				
+				assert((p1 < p2));
+				assert(p2 < end);
+				int part1 = p1 - begin;
+				int part2 = p2 - p1;
+				int part3 = end - p2;
+				if (part2 > part1 && part3 > part1) { //Partition 1 is the smallest
+					*s = p1 + 1;
+					*(s + 1) = p2;
+					*(s + 2) = p2 + 1;
+					*(s + 3) = end;
+					end = p1;
+				}
+				else if(part1 > part2 && part3 > part2) { //Partition 2 is the smallest
+					*s = begin;
+					*(s + 1) = p1;
+					*(s + 2) = p2 + 1;
+					*(s + 3) = end;
+					begin = p1 + 1;
+					end = p2;
+				}
+				else {
+					*s = begin;
+					*(s + 1) = p1;
+					*(s + 2) = p1 + 1;
+					*(s + 3) = p2;
+					begin = p2 + 1;
+				}
+				assert(begin <= end);
+				s += 4;
+				*d_s_top = ++depth;
+				*(d_s_top+1) = ++depth;
+				d_s_top += 2;
+
+			}
+			else {
+				
+				if (end - begin > 1000) { // if recursion depth limit exceeded
+#ifdef PARTIAL_SORT_COUNT
+					partial_sort_count++;
+#endif
+					std::partial_sort(begin, end, end);
+				}
+#ifndef NOINSERTIONSORT
+				else {
+					quicksort::qsort<partition::Hoare_block_partition_mosqrt>(begin, end, less);
+				}
+#endif 			
+				//pop new subarray from stack
+				s -= 2;
+				begin = *s;
+				end = *(s + 1);
+				--d_s_top;
+				assert(d_s_top != (depth_stack-1));
+				depth = *d_s_top;
+				assert(begin <= end);
+			}
+		} while (s != stack);
+	}
+
+
+	template<template<class , class> class Partitioner, typename iter, typename Compare>
+	inline void qsort_dual_pivot_equal_elements_thousand(iter begin, iter end, Compare less) {
+		const int depth_limit = 2 * ilogb((double)(end - begin)) + 3;
+		iter stack[80];
+		iter* s = stack;
+		int depth_stack[80];
+		int depth = 0;
+		int* d_s_top = depth_stack;
+		*s = begin;
+		*(s + 1) = end;
+		s += 2;
+		*d_s_top = 0;
+		++d_s_top;
+		do {
+			assert((end >= begin));
+			if (depth < depth_limit && (end - begin > 1000)) {
+				iter p1;
+				iter p2;
+				
+				Partitioner<iter, Compare>::partition(begin, end, &p1, &p2, less);
+				
+				if(*p1 == *p2){
+					//Disregard the middle partition
+					int part1 = p1 - begin;
+					int part3 = end - p2;
+					if (part1 > part3) {
+						*s = begin;
+						*(s + 1) = p1;
+						begin = p2 + 1;
+					}
+					else {
+						*s = p2 + 1; 
+						*(s + 1) = end;
+						end = p1;
+					}
+
+					s += 2;
+					depth++;
+					*d_s_top = depth;
+					++d_s_top;
+
+				}
+				else{
+					//Attempt at making things smaller
+					//Search, we remove all the elements equal to the pivot
+					iter tmp2 = p2;
+					while(*p2 == *(tmp2-1) && less(*p1, *(tmp2-1))) 
+						tmp2--;
+
+					//Search in the middle
+					iter tmp1 = p1;
+					while(*p1 == *(tmp1+1) && less(*(tmp1+1), *end))
+						tmp1++;
+					
+					int part1 = p1 - begin;
+					int part2 = tmp2 - tmp1;
+					int part3 = end - p2;
+
+					if (part2 > part1 && part3 > part1) { //Partition 1 is the smallest
+						*s = tmp1 + 1;
+						*(s + 1) = tmp2;
+						*(s + 2) = p2 + 1;
+						*(s + 3) = end;
+						end = p1;
+					}
+					else if(part1 > part2 && part3 > part2) { //Partition 2 is the smallest
+						*s = begin;
+						*(s + 1) = p1;
+						*(s + 2) = p2 + 1;
+						*(s + 3) = end;
+						begin = tmp1 + 1;
+						end = tmp2;
+					}
+					else {
+						*s = begin;
+						*(s + 1) = p1;
+						*(s + 2) = tmp1 + 1;
+						*(s + 3) = tmp2;
+						begin = p2 + 1;
+					}
+					assert(begin <= end);
+					s += 4;
+					*d_s_top = ++depth;
+					*(d_s_top+1) = ++depth;
+					d_s_top += 2;
+				}
+				
+
+			}
+			else {
+				
+				if (end - begin > 1000) { // if recursion depth limit exceeded
+#ifdef PARTIAL_SORT_COUNT
+					partial_sort_count++;
+#endif
+					std::partial_sort(begin, end, end);
+				}
+#ifndef NOINSERTIONSORT
+				else {
+					quicksort::qsort<partition::Hoare_block_partition_mosqrt>(begin, end, less);
+				}
+#endif 			
+				//pop new subarray from stack
+				s -= 2;
+				begin = *s;
+				end = *(s + 1);
+				--d_s_top;
+				assert(d_s_top != (depth_stack-1));
+				depth = *d_s_top;
+				assert(begin <= end);
+			}
+		} while (s != stack);
+	}
+
+
 
 }


### PR DESCRIPTION
This pull requests represents the code/work done by me (Nikolaj Hass) and Mikkel Angaju Rasmussen in school project at the IT University of Copenhagen with Martin Aumüller as supervisor. 

# Changes
## Changes to the README
We have added some explanations of the different methods in the README, however mostly about the methods we added ourselves to the makefile. 

## Changes to the makefile
- Added option to build a single algorithm
- Added option to build single algorithm with a specified type
- Added the different Dual-Pivot BlockQuickSort algorithms to the various algorithm lists
- Added new method to run BlockSize tests (Running the basic Blocked alg and Dual-Pivot blocked alg). 
- Added method to test the algs with the perf command (Requires perf, only tested on Linux)
- Made own custom timetest

## Changes to median.h 
Added pivot selection strategies for Dual-Pivot Quicksort:
- Tertiles of 5
- Skewed tertiles of 5

## Changes to quicksort.h
- Added quicksort logic to deal with two pivots.
- Added quicksort logic to deal with equal elements, reducing or disregarding then middle partition 

## Changes to partition.h
Added partitioning logic for Dual-Pivot BlockQuickSort

# Additions
The following algorithms have been added with the two pivot selection strategies mentioned earlier: 
- Dual-Pivot BlockQuickSort 
- Dual-Pivot BlockQuickSort with equal elements handling
- Dual-Pivot BlockQuickSort with fallback to BlockQuickSort at a 1000 elements


Please let me know if there is any issues with the pull-request!