### PR TITLE
Lomuto BlockQuickSort

### DIFF
--- a/lomuto_blocked.h++
+++ b/lomuto_blocked.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort<partition::Lomuto_block_partition>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort<partition::Lomuto_block_partition>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual.h++
+++ b/lomuto_blocked_dual.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_elements.h++
+++ b/lomuto_blocked_dual_elements.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_elements {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_2_pivot<partition::Dual_Lomuto_Block_partition_elements>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_2_pivot<partition::Dual_Lomuto_Block_partition_elements>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_elements_first_forth.h++
+++ b/lomuto_blocked_dual_elements_first_forth.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_elements_first_forth {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_first_forth>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_first_forth>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_elements_first_seventh.h++
+++ b/lomuto_blocked_dual_elements_first_seventh.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_elements_first_seventh {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_first_seventh>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_first_seventh>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_elements_move.h++
+++ b/lomuto_blocked_dual_elements_move.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_elements_move {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_move>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_move>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_elements_move_first_forth.h++
+++ b/lomuto_blocked_dual_elements_move_first_forth.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_elements_move_first_forth {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_move_first_forth>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_move_first_forth>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_elements_move_first_seventh.h++
+++ b/lomuto_blocked_dual_elements_move_first_seventh.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_elements_move_first_seventh {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_move_first_seventh>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_move_first_seventh>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_elements_move_second_forth.h++
+++ b/lomuto_blocked_dual_elements_move_second_forth.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_elements_move_second_forth {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_move_second_forth>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_move_second_forth>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_elements_move_third_fifth.h++
+++ b/lomuto_blocked_dual_elements_move_third_fifth.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_elements_move_third_fifth {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_move_third_fifth>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_move_third_fifth>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_elements_optimized.h++
+++ b/lomuto_blocked_dual_elements_optimized.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_elements_optimized {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_optimized>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_optimized>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_elements_second_forth.h++
+++ b/lomuto_blocked_dual_elements_second_forth.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_elements_second_forth {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_second_forth>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_second_forth>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_elements_third_fifth.h++
+++ b/lomuto_blocked_dual_elements_third_fifth.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_elements_third_fifth {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_third_fifth>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_third_fifth>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_first_forth.h++
+++ b/lomuto_blocked_dual_first_forth.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_first_forth {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_first_forth>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_first_forth>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_first_seventh.h++
+++ b/lomuto_blocked_dual_first_seventh.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_first_seventh {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_first_seventh>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_first_seventh>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_generated_test.h++
+++ b/lomuto_blocked_dual_generated_test.h++
@@ -1,0 +1,55 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+namespace lomuto_blocked_dual_generated_test {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_generated_test>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_elements_generated_test>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_merge.h++
+++ b/lomuto_blocked_dual_merge.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_merge {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_merge>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_merge>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_merge_first_forth.h++
+++ b/lomuto_blocked_dual_merge_first_forth.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_merge_first_forth {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_merge_first_forth>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_merge_first_forth>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_merge_first_seventh.h++
+++ b/lomuto_blocked_dual_merge_first_seventh.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_merge_first_seventh {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_merge_first_seventh>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_merge_first_seventh>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_merge_second_forth.h++
+++ b/lomuto_blocked_dual_merge_second_forth.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_merge_second_forth {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_merge_second_forth>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_merge_second_forth>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_merge_third_fifth.h++
+++ b/lomuto_blocked_dual_merge_third_fifth.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_merge_third_fifth {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_merge_third_fifth>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_merge_third_fifth>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_second_forth.h++
+++ b/lomuto_blocked_dual_second_forth.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_second_forth {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_second_forth>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_second_forth>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_third_fifth.h++
+++ b/lomuto_blocked_dual_third_fifth.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_third_fifth {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_third_fifth>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_third_fifth>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_while.h++
+++ b/lomuto_blocked_dual_while.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_while {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_while>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_while>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_while_first_forth.h++
+++ b/lomuto_blocked_dual_while_first_forth.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_while_first_forth {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_while_first_forth>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_while_first_forth>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_while_first_seventh.h++
+++ b/lomuto_blocked_dual_while_first_seventh.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_while_first_seventh {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_while_first_seventh>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_while_first_seventh>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_while_second_forth.h++
+++ b/lomuto_blocked_dual_while_second_forth.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_while_second_forth {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_while_second_forth>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_while_second_forth>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_dual_while_third_fifth.h++
+++ b/lomuto_blocked_dual_while_third_fifth.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_dual_while_third_fifth {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_while_third_fifth>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort_dual_pivot<partition::Dual_Lomuto_Block_partition_while_third_fifth>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_less.h++
+++ b/lomuto_blocked_less.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_less {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort<partition::Lomuto_block_partition_less>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort<partition::Lomuto_block_partition_less>(begin, end, std::less<T>());
+	}
+}

--- a/lomuto_blocked_simple.h++
+++ b/lomuto_blocked_simple.h++
@@ -1,0 +1,56 @@
+/******************************************************************************
+* blocked_simple.h++
+*
+* interface for BlockQuicksort simple with median-of-three
+*
+******************************************************************************
+* Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
+* Copyright (C) 2016 Armin Wei� <armin.weiss@fmi.uni-stuttgart.de>
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation, either version 3 of the License, or (at your option)
+* any later version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*****************************************************************************/
+
+
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+#include <string>
+#include <stdlib.h>
+#include <random>
+#include <ctime>
+#include <cmath>
+#include <assert.h>
+
+
+#include "insertionsort.h"
+#include "median.h"
+#include "partition.h"
+#include "quicksort.h"
+
+
+namespace lomuto_blocked_simple {
+	template<typename iter, typename Compare>
+	void sort(iter begin, iter end, Compare less) {
+		quicksort::qsort<partition::Lomuto_block_partition_simple>(begin, end, less);
+	}
+	template<typename T>
+	void sort(std::vector<T> &v) {
+		typename std::vector<T>::iterator begin = v.begin();
+		typename std::vector<T>::iterator end = v.end();
+		quicksort::qsort<partition::Lomuto_block_partition_simple>(begin, end, std::less<T>());
+	}
+}

--- a/median.h
+++ b/median.h
@@ -5,7 +5,7 @@
 *
 ******************************************************************************
 * Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
-* Copyright (C) 2016 Armin Weiß <armin.weiss@fmi.uni-stuttgart.de>
+* Copyright (C) 2016 Armin Weiï¿½ <armin.weiss@fmi.uni-stuttgart.de>
 *
 * This program is free software: you can redistribute it and/or modify it
 * under the terms of the GNU General Public License as published by the Free
@@ -227,5 +227,235 @@ namespace median {
 		std::swap_ranges(middle_p1, placeit, end - k/2);
 		assert(!(less(*(end - 1), *middle)));
 		return middle;
+	}
+
+
+	template<typename iter, typename Compare>
+	inline iter* mp_random(iter begin, iter end, Compare less){
+		iter sek1 = begin;
+		iter sek2 = begin+1;
+		sort_pair(sek1, sek2, less);
+		
+		/*
+		int tmp = (end-begin)/4;
+		iter sek1 = begin+tmp;
+		iter sek2 = begin+(2*tmp);
+		iter sek3 = begin+(3*tmp);
+		sort_pair(begin, sek1, less);
+		sort_pair(sek3, end, less);
+		sort_pair(sek2, end, less);
+		sort_pair(sek2, sek3, less);
+		sort_pair(begin, sek3, less);
+		sort_pair(begin, sek2, less);
+		sort_pair(sek1, end, less);
+		sort_pair(sek1, sek3, less);
+		sort_pair(sek1, sek2, less);*/
+		iter* ret = new iter[2];
+		ret[0] = sek1;
+		ret[1] = sek2; 
+		return ret;
+	}
+
+	template<typename iter, typename Compare>
+	inline iter* mp_tertiles_of_3_pivots_2(iter begin, iter end, Compare less){
+		int tmp = (end-begin)/4;
+		iter sek1 = begin+tmp;
+		iter sek2 = begin+(2*tmp);
+		iter sek3 = begin+(3*tmp);
+		sort_pair(begin, sek1, less);
+		sort_pair(sek3, end, less);
+		sort_pair(sek2, end, less);
+		sort_pair(sek2, sek3, less);
+		sort_pair(begin, sek3, less);
+		sort_pair(begin, sek2, less);
+		sort_pair(sek1, end, less);
+		sort_pair(sek1, sek3, less);
+		sort_pair(sek1, sek2, less);
+		iter* ret = new iter[2];
+		ret[0] = sek1;
+		ret[1] = sek3; 
+		return ret;
+	}
+	template<typename iter, typename Compare>
+	inline iter* mp_tertiles_of_5_pivots_2(iter begin, iter end, Compare less){
+		int tmp = (end-begin)/6;
+		iter sek1 = begin+tmp;
+		iter sek2 = begin+(2*tmp);
+		iter sek3 = begin+(3*tmp);
+		iter sek4 = begin+(4*tmp);
+		iter sek5 = begin+(5*tmp);
+
+		sort_pair(sek1, sek2, less);
+		sort_pair(sek4, sek5, less);
+		sort_pair(sek3, sek5, less);
+		sort_pair(sek3, sek4, less);
+		sort_pair(sek1, sek4, less);	
+		sort_pair(sek1, sek3, less);
+		sort_pair(sek2, sek5, less);
+		sort_pair(sek2, sek4, less);
+		sort_pair(sek2, sek3, less);
+		assert(sek2 != sek4);
+		iter* ret = new iter[2];
+		ret[0] = sek2;
+		ret[1] = sek4; 
+		return ret;
+	}
+
+	template<typename iter, typename Compare>
+	inline iter* mp_third_fifth_element(iter begin, iter end, Compare less){
+		//Based on: http://jgamble.ripco.net/cgi-bin/nw.cgi?inputs=7&algorithm=best&output=macro
+		int tmp = (end-begin)/6;
+		iter sek0 = begin;
+		iter sek1 = begin+tmp;
+		iter sek2 = begin+(tmp*2);
+		iter sek3 = begin+(tmp*3);
+		iter sek4 = begin+(tmp*4);
+		iter sek5 = begin+(tmp*5);
+		iter sek6 = end-1;
+
+		sort_pair(sek1, sek2, less);
+		sort_pair(sek0, sek2, less);
+		sort_pair(sek0, sek1, less);
+		sort_pair(sek3, sek4, less);
+		sort_pair(sek5, sek6, less);
+		sort_pair(sek3, sek5, less);
+		sort_pair(sek4, sek6, less);
+		sort_pair(sek4, sek5, less);
+		sort_pair(sek0, sek4, less);
+		sort_pair(sek0, sek3, less);
+		sort_pair(sek1, sek5, less);
+		sort_pair(sek2, sek6, less);
+		sort_pair(sek2, sek5, less);
+		sort_pair(sek1, sek3, less);
+		sort_pair(sek2, sek4, less);
+		sort_pair(sek2, sek3, less);
+		iter* ret = new iter[2];
+		ret[0] = sek2;
+		ret[1] = sek4; 
+		return ret;
+	}
+
+	template<typename iter, typename Compare>
+	inline iter* mp_second_forth_element(iter begin, iter end, Compare less){
+		//Based on: http://jgamble.ripco.net/cgi-bin/nw.cgi?inputs=7&algorithm=best&output=macro
+		int tmp = (end-begin)/6;
+		iter sek0 = begin;
+		iter sek1 = begin+tmp;
+		iter sek2 = begin+(tmp*2);
+		iter sek3 = begin+(tmp*3);
+		iter sek4 = begin+(tmp*4);
+		iter sek5 = begin+(tmp*5);
+		iter sek6 = end-1;
+
+		sort_pair(sek1, sek2, less);
+		sort_pair(sek0, sek2, less);
+		sort_pair(sek0, sek1, less);
+		sort_pair(sek3, sek4, less);
+		sort_pair(sek5, sek6, less);
+		sort_pair(sek3, sek5, less);
+		sort_pair(sek4, sek6, less);
+		sort_pair(sek4, sek5, less);
+		sort_pair(sek0, sek4, less);
+		sort_pair(sek0, sek3, less);
+		sort_pair(sek1, sek5, less);
+		sort_pair(sek2, sek6, less);
+		sort_pair(sek2, sek5, less);
+		sort_pair(sek1, sek3, less);
+		sort_pair(sek2, sek4, less);
+		sort_pair(sek2, sek3, less);
+		iter* ret = new iter[2];
+		ret[0] = sek1;
+		ret[1] = sek3; 
+		return ret;
+	}
+
+
+	template<typename iter, typename Compare>
+	inline iter* mp_first_forth_element(iter begin, iter end, Compare less){
+		//Based on: http://jgamble.ripco.net/cgi-bin/nw.cgi?inputs=7&algorithm=best&output=macro
+		int tmp = (end-begin)/6;
+		iter sek0 = begin;
+		iter sek1 = (begin+tmp);
+		iter sek2 = begin+(tmp*2);
+		iter sek3 = begin+(tmp*3);
+		iter sek4 = begin+(tmp*4);
+		iter sek5 = begin+(tmp*5);
+		iter sek6 = end-1;
+
+		sort_pair(sek1, sek2, less);
+		sort_pair(sek0, sek2, less);
+		sort_pair(sek0, sek1, less);
+		sort_pair(sek3, sek4, less);
+		sort_pair(sek5, sek6, less);
+		sort_pair(sek3, sek5, less);
+		sort_pair(sek4, sek6, less);
+		sort_pair(sek4, sek5, less);
+		sort_pair(sek0, sek4, less);
+		sort_pair(sek0, sek3, less);
+		sort_pair(sek1, sek5, less);
+		sort_pair(sek2, sek6, less);
+		sort_pair(sek2, sek5, less);
+		sort_pair(sek1, sek3, less);
+		sort_pair(sek2, sek4, less);
+		sort_pair(sek2, sek3, less);
+		iter* ret = new iter[2];
+		ret[0] = sek0;
+		ret[1] = sek3; 
+		return ret;
+	}
+
+
+	//Something wrong here
+	//Might be the last element?
+	template<typename iter, typename Compare>
+	inline iter* mp_first_seventh_element(iter begin, iter end, Compare less){
+		//Based on: http://jgamble.ripco.net/cgi-bin/nw.cgi?inputs=7&algorithm=best&output=macro
+		int tmp = (end-begin)/6;
+		iter sek0 = begin;
+		iter sek1 = begin+tmp;
+		iter sek2 = begin+(tmp*2);
+		iter sek3 = begin+(tmp*3);
+		iter sek4 = begin+(tmp*4);
+		iter sek5 = begin+(tmp*5);
+		iter sek6 = end-1;
+		std::cout << "End: " << *end << std::endl;
+		std::cout << "Sek0: " << *sek0 << std::endl;
+		std::cout << "Sek1: " << *sek1 << std::endl;
+		std::cout << "Sek2: " << *sek2 << std::endl;
+		std::cout << "Sek3: " << *sek3 << std::endl;
+		std::cout << "Sek4: " << *sek4 << std::endl;
+		std::cout << "Sek5: " << *sek5 << std::endl;
+		std::cout << "Sek6: " << *sek6 << std::endl;
+
+		sort_pair(sek1, sek2, less);
+		sort_pair(sek0, sek2, less);
+		sort_pair(sek0, sek1, less);
+		sort_pair(sek3, sek4, less);
+		sort_pair(sek5, sek6, less);
+		sort_pair(sek3, sek5, less);
+		sort_pair(sek4, sek6, less);
+		sort_pair(sek4, sek5, less);
+		sort_pair(sek0, sek4, less);
+		sort_pair(sek0, sek3, less);
+		sort_pair(sek1, sek5, less);
+		sort_pair(sek2, sek6, less);
+		sort_pair(sek2, sek5, less);
+		sort_pair(sek1, sek3, less);
+		sort_pair(sek2, sek4, less);
+		sort_pair(sek2, sek3, less);
+		iter* ret = new iter[2];
+		std::cout << "End: SECOND  " << *end << std::endl;
+		std::cout << "Sek0: " << *sek0 << std::endl;
+		std::cout << "Sek1: " << *sek1 << std::endl;
+		std::cout << "Sek2: " << *sek2 << std::endl;
+		std::cout << "Sek3: " << *sek3 << std::endl;
+		std::cout << "Sek4: " << *sek4 << std::endl;
+		std::cout << "Sek5: " << *sek5 << std::endl;
+		std::cout << "Sek6: " << *sek6 << std::endl;
+		ret[0] = sek0;
+		ret[1] = sek6; 
+		std::cout << "Sek0: " << *sek0 << std::endl;
+		std::cout << "Sek6: " << *sek6 << std::endl;
+		return ret;
 	}
 }

--- a/partition.h
+++ b/partition.h
@@ -37,9 +37,8 @@
 #include <assert.h>
 #include <functional>
 #include "rotations.h"
-//#defineMOREPARTITIONERS
 #ifndef BLOCKSIZE
-#define BLOCKSIZE 128//2//128
+#define BLOCKSIZE 128
 #endif
 #ifndef PIVOTSAMPLESIZE
 #define PIVOTSAMPLESIZE 23

--- a/partition.h
+++ b/partition.h
@@ -7,7 +7,7 @@
 *
 ******************************************************************************
 * Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
-* Copyright (C) 2016 Armin Weiß <armin.weiss@fmi.uni-stuttgart.de>
+* Copyright (C) 2016 Armin Weiï¿½ <armin.weiss@fmi.uni-stuttgart.de>
 *
 * This program is free software: you can redistribute it and/or modify it
 * under the terms of the GNU General Public License as published by the Free
@@ -36,10 +36,10 @@
 #include <cmath>
 #include <assert.h>
 #include <functional>
-
+#include "rotations.h"
 //#defineMOREPARTITIONERS
 #ifndef BLOCKSIZE
-#define BLOCKSIZE 128
+#define BLOCKSIZE 128//2//128
 #endif
 #ifndef PIVOTSAMPLESIZE
 #define PIVOTSAMPLESIZE 23
@@ -151,7 +151,7 @@ namespace partition {
 
 		}//end main loop
 
-		 //Compare and store in buffers final iteration
+		//Compare and store in buffers final iteration
 		index shiftR = 0, shiftL = 0;
 		if (num_right == 0 && num_left == 0) {	//for small arrays or in the unlikely case that both buffers are empty
 			shiftL = ((last - begin) + 1) / 2;
@@ -1064,5 +1064,1416 @@ namespace partition {
 		}
 	};
 
+	template<typename iter>
+	void printArray(iter begin, iter end,  const std::string &desc) {
+		int i = 0;
 
+		if((end - begin) < 0) {
+			std::cout << desc << " printing failed because begin was above end" << std::endl;
+			
+			return;
+		}
+		iter begin2 = begin;
+		iter end2 = end;
+		std::cout << "Printing array: " << desc << std::endl;
+		while (begin2 != end2) {
+			
+			std::cout << *begin2 << " ";
+			begin2++;
+			i++;
+			
+		}
+		std::cout << std::endl;
+
+	}
+
+
+	template<typename iter, typename Compare>
+	inline void multi_pivot_2_block_partition_simple(iter begin, iter end, iter* pivot_positions, Compare less, iter* ret1, iter* ret2) {
+		typedef typename std::iterator_traits<iter>::difference_type index;		
+		int block = 2 * BLOCKSIZE;
+
+		index R[block], L[block];
+
+		iter last = end-1;
+		//Moving pivots to the last positions
+		std::iter_swap(pivot_positions[0], begin);
+		std::iter_swap(pivot_positions[1], last);
+		const typename std::iterator_traits<iter>::value_type & p1 = *begin;
+		const typename std::iterator_traits<iter>::value_type & p2 = *last;
+		pivot_positions[0] = begin;
+		pivot_positions[1] = last;
+		last--;
+		begin++;
+
+		int num_ll = 0;
+		int num_lr = 0;
+		int num_rl = 0;
+		int num_rr = 0;
+		iter middle = begin;
+		int delta = BLOCKSIZE;
+		int start_ll = 0;
+		int start_lr = 0;
+		int start_rl = 0;
+		int start_rr = 0;
+		int num;
+		index i, j;
+		while (last - begin + 1 > 2 * BLOCKSIZE) {
+			if(num_ll == 0 && num_lr == 0) {
+				start_ll = 0;
+				start_lr = 0;
+				for (i = 0; i < BLOCKSIZE; i++) {
+					L[num_ll] = i;
+					L[delta + num_lr] = i;
+
+					//Is it in the right partition
+					num_lr += less(p2, begin[i]);
+					//Is it in the left partition
+					num_ll += less(begin[i], p1);
+				}
+			}
+
+			if(num_rl == 0 && num_rr == 0) {
+				start_rl = 0;
+				start_rr = 0;
+				for (j = 0; j < BLOCKSIZE; j++) {
+					R[num_rl] = j;
+					R[delta + num_rr] = j;
+					
+					//Current index
+					auto leftIndex = (last - j);
+					//Is it in the left partition
+					int b1 = (less(*leftIndex, p1));
+					num_rl += b1;
+					//Is it in the middle partition
+					num_rr += (!b1 && !less(p2, *leftIndex));
+				}
+			}
+
+			//Rearrange the elements
+			//Swap lr with rr
+			
+			num = std::min(num_lr, num_rr);
+			for (int k = 0; k < num; k++) {
+				std::iter_swap(begin + L[start_lr + delta + k], last-R[start_rr + delta + k]);
+			}
+			start_lr += num;
+			start_rr += num;
+			num_lr -= num;
+			num_rr -= num;
+
+			//Edge case where we have empty LL elements that are already in place
+			
+			if(middle == begin) {
+				int ll = 0;
+				while (*(L + start_ll) == ll && num_ll > 0 ){
+					++start_ll;
+					--num_ll;
+					++ll;
+					middle++;
+				}
+			}
+
+			//lr <-> rl
+			num = std::min(num_lr, num_rl);
+			for (int k = 0; k < num; k++) {
+				//Ensuring our middle partition is large enough
+				while (*(L + start_ll) < *(L + start_lr + delta + k) && num_ll > 0) {
+					std::iter_swap(middle, begin + L[start_ll]);
+					++start_ll;
+					--num_ll;
+					++middle;
+				}
+				rotations::rotate3(*(begin + L[start_lr + delta + k]), *middle, *(last - R[start_rl + k]));
+				middle++;
+			} 
+			
+			start_rl += num;
+			start_lr += num;
+			num_rl -= num;
+			num_lr -= num;
+			
+			//Empty ll
+			if(num_lr == 0) { 
+				for(int k = 0; k < num_ll; k++) {
+					std::iter_swap(begin + L[start_ll + k], middle);
+					middle++;
+				}
+				start_ll += num_ll;
+				num_ll = 0;
+			}		
+
+			begin += (num_ll == 0 && num_lr == 0) ? BLOCKSIZE : 0;
+			last -= (num_rl == 0 && num_rr == 0) ? BLOCKSIZE : 0;
+		}
+		
+		//Compare and store in buffers final iteration
+		index shiftR = 0;
+		index shiftL = 0;
+		if(num_ll == 0 && num_lr == 0 && num_rl == 0 && num_rr == 0) {
+			shiftL = ((last-begin) + 1) / 2; 
+			shiftR = (last - begin) + 1 - shiftL;
+			start_ll = 0;
+			start_lr = 0;
+			start_rr = 0;
+			start_rl = 0;
+			for (index j = 0; j < shiftL; j++) {
+				L[num_ll] = j;
+				L[delta + num_lr] = j;
+				//Is it in the right partition
+				num_lr += less(p2, begin[j]);
+				//Is it in the left partition
+				num_ll += less(begin[j], p1);
+				R[num_rl] = j;
+				R[delta + num_rr] = j;
+				
+				//Current index
+				auto leftIndex = (last - j);
+				//Is it in the left partition
+				int b1 = (less(*leftIndex, p1));
+				num_rl += b1;
+				//Is it in the middle partition
+				num_rr += (!b1 && !(less(p2, *leftIndex)));
+			}
+			
+			if(shiftL < shiftR) {
+				auto subIndex = (last - shiftR + 1);
+				int b1 = (less(*subIndex, p1));
+				R[num_rl] = shiftR - 1;
+				R[delta + num_rr] = shiftR - 1;
+				num_rl += b1;
+				num_rr += !b1 && !less(p2, *subIndex);
+			}
+		}
+		else if(num_rl != 0 || num_rr != 0) {
+			shiftL = (last - begin) - BLOCKSIZE + 1;
+			shiftR = BLOCKSIZE;
+			start_ll = 0;
+			start_lr = 0;
+			for(index j = 0; j < shiftL; j++) {
+				L[num_ll] = j;
+				L[delta + num_lr] = j;
+				num_ll += (less(begin[j], p1));
+				num_lr += less(p2, begin[j]);
+			}
+		} else {
+			shiftL = BLOCKSIZE;
+			shiftR = (last - begin) - BLOCKSIZE + 1;
+			start_rl = 0;
+			start_rr = 0;
+			for (index j = 0; j < shiftR; j++) {
+				R[num_rl] = j;
+				R[delta + num_rr] = j;
+				bool b1 = less(*(last-j), p1);
+				num_rl += b1;
+				num_rr += !b1 && !less(p2, *(last-j));
+			}
+		}
+
+		//rearrange final iteration
+		//Swap lr with rr
+		num = std::min(num_lr, num_rr);
+		for (int k = 0; k < num; k++) {
+			std::iter_swap(begin + L[start_lr + delta + k], last-R[start_rr + delta + k]);
+		}
+		start_lr += num;
+		start_rr += num;
+		num_lr -= num;
+		num_rr -= num;
+
+		//Edge case where we have empty LL elements that are already in place
+		int ll = 0;
+		if(middle == begin) {
+			while (*(L + start_ll) == ll && num_ll > 0 ){
+				++start_ll;
+				--num_ll;
+				++ll;
+				middle++;
+			}
+		}
+
+		//lr <-> rl
+		num = std::min(num_lr, num_rl);
+		for (int k = 0; k < num; k++) {
+			//Ensuring our middle partition is large enough
+			while (*(L + start_ll) < *(L + start_lr + delta + k) && num_ll > 0) {
+				std::iter_swap(middle, begin + L[start_ll]);
+				++start_ll;
+				--num_ll;
+				++middle;
+			}
+			rotations::rotate3(*(begin + L[start_lr + delta + k]), *middle, *(last - R[start_rl + k]));
+			middle++;
+		} 
+		
+		start_rl += num;
+		start_lr += num;
+		num_rl -= num;
+		num_lr -= num;
+		
+		//Empty ll
+		if(num_lr == 0) { 
+			for(int k = 0; k < num_ll; k++) {
+				std::iter_swap(begin + L[start_ll + k], middle);
+				middle++;
+			}
+			start_ll += num_ll;
+			num_ll = 0;
+		}		
+
+		begin += (num_ll == 0 && num_lr == 0) ? shiftL : 0;
+		last -= (num_rl == 0 && num_rr == 0) ? shiftR : 0;
+		
+		iter right = last+1;
+		
+		int k = 0;
+		int l = last - begin;
+		//TODO: More elegant way of detecting this?
+		bool rightLoop = num_rl != 0 || num_rr != 0;
+		
+		//If left side is empty, and right side has elements	
+		while(num_rl != 0 || num_rr != 0){
+			//search from left to right 
+			while((( num_rr != 0 && l == R[start_rr + delta + num_rr - 1] ) || (num_rl != 0 && l == R[start_rl + num_rl - 1])) && l > k ){
+				bool b = num_rl != 0 && (l == R[start_rl + num_rl - 1]); // 1 if left 
+				std::iter_swap(last - l, middle);
+				middle += b;
+				num_rr -= !b;
+				num_rl -= b;
+				l--;
+			}
+			
+			//search from right to left
+			while((num_rr == 0 || k != R[delta + start_rr]) && (num_rl == 0 || k != R[start_rl]) && l > k) 
+			{  
+				k++;
+			}
+			
+			bool mid = num_rr != 0 && k == R[delta + start_rr]; //Is 1 if element is a mid element, false no mid elements
+			bool left = num_rl != 0 && k == R[start_rl]; 
+			//Rotate last middle begin or last begin begin
+			rotations::rotate3(*(last - k) , *(last - l),   *((last - l) - (left * ((last - l) - middle))));
+			
+			l -= l > k;
+			k += l > k;	
+			middle += left;
+			start_rl += left;
+			num_rl -= left;
+			num_rr -= mid;
+			start_rr += mid;
+			assert(num_rr > -1); assert(num_rl > -1);
+		}
+		
+		
+		//If we executed the right loop and emptied the blocks we cannot 
+		//guarantee that the right pointer was moved all the way so we just move it by
+		//the difference between k and l.
+		if(rightLoop)
+			right = (last - l + (*(last - l) < p2)); //TODO: Can there be a more elegant way?
+
+		//Should ensure the edge case of middle being ahead of begin
+		k += middle - (begin + k);
+
+		//If right side is empty and left side has elements
+		while(num_ll != 0 || num_lr != 0) {
+
+			while(((num_lr != 0 && k != L[start_lr + delta]) || (num_ll != 0 && num_lr == 0)) && l > k) {
+				bool b = num_ll != 0 && (k == L[start_ll]);	
+				std::iter_swap(begin + k,  middle);	
+				middle += b;
+				num_ll -= b;
+				start_ll += b;
+				k++;
+			}
+
+
+			while( num_lr != 0 && l == L[start_lr + num_lr + delta - 1] && l > 0 && l > k) {
+				num_lr--;
+				l--;
+				right--;
+			}
+			bool b = num_ll != 0 && (l == L[start_ll + num_ll - 1]);
+			//Rotate last middle begin or last begin begin
+			rotations::rotate3(*(begin + l), *(begin + k), *((begin + k) - (b * ((begin + k) - middle))));
+			middle += b;
+			num_ll -= b;
+			
+			bool isRight = num_lr != 0;
+			num_lr -= isRight;
+			start_lr += isRight;
+			
+			l--;
+			k++;
+			right -= isRight;
+			assert(num_lr > -1); assert(num_ll > -1);
+		}
+
+		std::iter_swap(pivot_positions[0], middle - 1);
+		std::iter_swap(pivot_positions[1], right);
+		*ret1 = (middle - 1);
+		*ret2 = right;
+	}
+
+	//Multi-Pivot part 
+	template< typename iter, typename Compare>
+	struct Multi_Pivot_Hoare_Block_partition_simple {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_tertiles_of_3_pivots_2(begin, end-1, less);
+			multi_pivot_2_block_partition_simple(begin, end, pivots, less, p1, p2);
+		}
+	};
+
+	template< typename iter, typename Compare>
+	struct Multi_Pivot_Hoare_Block_partition_simple_mo5 {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_tertiles_of_5_pivots_2(begin, end-1, less);
+			multi_pivot_2_block_partition_simple(begin, end, pivots, less, p1, p2);
+		}
+	};	
+
+
+
+	//Lomuto based part
+
+	template<typename iter, typename Compare>
+	inline iter lomuto_block_partition_simple(iter begin, iter end, iter pivot_position, Compare less) {
+		typedef typename std::iterator_traits<iter>::difference_type index;
+		index indexL[BLOCKSIZE];
+		iter last = end - 1;
+		std::iter_swap(pivot_position, last);
+		const typename std::iterator_traits<iter>::value_type & pivot = *last;
+		pivot_position = last;
+		iter counter = begin;
+		last--;
+
+		int num_left = 0;
+		int start_left = 0;
+		//main loop
+		iter offset = begin;
+
+		while (last - counter + 1 > 0)//BLOCKSIZE)
+		{
+			int t = (last-counter+1);
+			int limit = std::min(BLOCKSIZE, t);
+			for (index j = 0; j < limit; j++) {
+					indexL[num_left] = j;
+					num_left += less(counter[j], pivot);				
+			}
+			//rearrange elements
+			
+			for (int j = 0; j < num_left; j++){
+				std::iter_swap(offset, counter+indexL[start_left+j]);
+				offset++;
+			}
+
+			num_left = 0;//num;
+			start_left =0;// num;
+			counter += limit;
+
+		}//end main loop
+
+		std::iter_swap(pivot_position, offset);// fetch the pivot 
+		return offset;
+	}
+
+	template<typename iter, typename Compare>
+	inline iter lomuto_block_partition(iter begin, iter end, iter pivot_position, Compare less) {
+		typedef typename std::iterator_traits<iter>::difference_type index;
+		index indexL[BLOCKSIZE];
+		iter last = end - 1;
+		std::iter_swap(pivot_position, last);
+		const typename std::iterator_traits<iter>::value_type & pivot = *last;
+		pivot_position = last;
+		iter counter = begin;
+		last--;
+
+		int num_left = 0;
+		int start_left = 0;
+		//main loop
+		iter offset = begin;
+
+		while (last - counter + 1 > BLOCKSIZE)//BLOCKSIZE)
+		{
+			//Compare and store in buffers
+			for (index j = 0; j < BLOCKSIZE; j++) {
+					indexL[num_left] = j;
+					num_left += less(counter[j], pivot);				
+			}
+			//rearrange elements
+			
+			for (int j = 0; j < num_left; j++){
+				std::iter_swap(offset, counter+indexL[start_left+j]);
+				offset++;
+			}
+
+			num_left = 0;//num;
+			start_left =0;// num;
+			counter += BLOCKSIZE;
+
+		}//end main loop
+		
+		int t = (last-counter+1);
+		//int limit = std::min(BLOCKSIZE, t);
+		for (index j = 0; j < t; j++) {
+				indexL[num_left] = j;
+				num_left += less(counter[j], pivot);				
+		}
+		//rearrange elements
+		
+		for (int j = 0; j < num_left; j++){
+			std::iter_swap(offset, counter+indexL[start_left+j]);
+			offset++;
+		}
+
+	//	num_left = 0;//num;
+	//	start_left =0;// num;
+	//	counter += t;
+
+		std::iter_swap(pivot_position, offset);// fetch the pivot 
+		return offset;
+	}
+
+	template<typename iter, typename Compare>
+	inline iter lomuto_block_partition_less(iter begin, iter end, iter pivot_position, Compare less) {
+		typedef typename std::iterator_traits<iter>::difference_type index;
+		index indexL[BLOCKSIZE];
+		iter last = end - 1;
+		std::iter_swap(pivot_position, last);
+		const typename std::iterator_traits<iter>::value_type & pivot = *last;
+		pivot_position = last;
+		iter counter = begin;
+		last--;
+
+		int num_left = 0;
+		int start_left = 0;
+		//main loop
+		iter offset = begin;
+
+		while (last - counter + 1 > BLOCKSIZE)//BLOCKSIZE)
+		{
+			//Compare and store in buffers
+			for (index j = 0; j < BLOCKSIZE; j++) {
+					indexL[num_left] = j;
+					num_left += less(counter[j], pivot);				
+			}
+			//rearrange elements
+			
+			for (int j = 0; j < num_left; j++){
+				std::iter_swap(offset+j, counter+indexL[start_left+j]);
+				//offset++;
+			}
+			offset += num_left;
+			num_left = 0;//num;
+			start_left =0;// num;
+			counter += BLOCKSIZE;
+
+		}//end main loop
+		
+		int t = (last-counter+1);
+		//int limit = std::min(BLOCKSIZE, t);
+		for (index j = 0; j < t; j++) {
+				indexL[num_left] = j;
+				num_left += less(counter[j], pivot);				
+		}
+		//rearrange elements
+		
+		for (int j = 0; j < num_left; j++){
+			std::iter_swap(offset+j, counter+indexL[start_left+j]);
+			//offset++;
+		}
+		offset+= num_left;
+	//	num_left = 0;//num;
+	//	start_left =0;// num;
+		//counter += t;
+
+		std::iter_swap(pivot_position, offset);// fetch the pivot 
+		return offset;
+	}
+
+	template<typename iter, typename Compare>
+	struct Lomuto_block_partition_simple {
+		static inline iter partition(iter begin, iter end, Compare less) {
+			//choose pivot
+			iter mid = median::median_of_3(begin, end, less);
+			//partition
+			return lomuto_block_partition_simple(begin, end, mid, less);
+		}
+		static inline iter partition(iter begin, iter end, iter pivot, Compare less) {
+			//partition
+			return lomuto_block_partition_simple(begin, end, pivot, less);
+		}
+	};
+
+	template<typename iter, typename Compare>
+	struct Lomuto_block_partition {
+		static inline iter partition(iter begin, iter end, Compare less) {
+			//choose pivot
+			iter mid = median::median_of_3(begin, end, less);
+			//partition
+			return lomuto_block_partition(begin, end, mid, less);
+		}
+		static inline iter partition(iter begin, iter end, iter pivot, Compare less) {
+			//partition
+			return lomuto_block_partition(begin, end, pivot, less);
+		}
+	};
+
+	template<typename iter, typename Compare>
+	struct Lomuto_block_partition_less {
+		static inline iter partition(iter begin, iter end, Compare less) {
+			//choose pivot
+			iter mid = median::median_of_3(begin, end, less);
+			//partition
+			return lomuto_block_partition(begin, end, mid, less);
+		}
+		static inline iter partition(iter begin, iter end, iter pivot, Compare less) {
+			//partition
+			return lomuto_block_partition(begin, end, pivot, less);
+		}
+	};
+
+
+	
+	template<typename iter, typename Compare>
+	inline void dual_lomuto_block_partition_simple(iter begin, iter end, iter* pivot_positions, Compare less, iter* ret1, iter* ret2) {
+		typedef typename std::iterator_traits<iter>::difference_type index;		
+		index block1[BLOCKSIZE], block2[BLOCKSIZE];
+		//index R[block], L[block];
+
+		iter last = end-1;
+		//Moving pivots to the last positions
+		//std::cout << "pivots: " << *pivot_positions[0] << " " << *pivot_positions[1] << std::endl;
+		
+		std::iter_swap(pivot_positions[0], last);
+		const typename std::iterator_traits<iter>::value_type & p1 = *last;
+		pivot_positions[0] = last;
+		last--;
+		std::iter_swap(pivot_positions[1], last);
+		const typename std::iterator_traits<iter>::value_type & p2 = *last;
+		pivot_positions[1] = last;
+		last--;
+		//printArray(begin, end, "Start array");
+
+		int num1 = 0;
+		int num2 = 0;
+		int start1 = 0;
+		int start2 = 0;
+		iter counter = begin;
+		iter offset1 = begin;
+		iter offset2 = begin;
+		int num;
+		while (last - counter + 1 > 0) {
+
+			//Seg fault issue here, look at simple
+			int t = (last-counter+1);
+			int limit = std::min(BLOCKSIZE, t);
+			for (index j = 0; j < limit; j++) {
+					block1[num1] = j;
+					int o = less(counter[j], p1);
+					num1 += o;	
+					block2[num2] = j;
+					num2 += less(counter[j], p2) - o;
+			}
+			//Rearrange the elements
+			//Find the first element we have stored in a block
+			num = num1+num2;
+			int k = 0; 
+			while(k < num){
+				int res = (block2[start2] < block1[start1]) ? block2[start2] : block1[start1];
+				int b = (res == block2[start2] && num2 != 0);
+				auto difference = (offset2-offset1);
+				rotations::rotate3(*(counter+res), *offset2, *(offset1 + (difference * b)));
+				offset2++;
+				offset1 += 1-b;
+				start1 += 1-b;
+				start2 += b;
+				num1 -= 1-b;
+				num2 -= b;
+				k++;
+			
+
+			}
+			start1 = 0;
+			start2 = 0;
+			num1 = 0;
+			num2 = 0;
+			counter += limit;
+
+		}
+
+		/*std::cout << "offset1: " << *offset1 << std::endl;
+		std::cout << "offset2: " << *offset2 << std::endl;	
+		printArray(begin, end, " End array");*/
+		rotations::rotate3(*offset2, *offset1, *(end-1));
+		//std::iter_swap(www, offset2);
+		//std::iter_swap(offset2, offset1);
+		offset2++;
+		std::iter_swap(end-2, offset2);
+		//
+		*ret1 = offset1;
+		*ret2 = offset2;
+	}
+
+	template<typename iter, typename Compare>
+	inline void dual_lomuto_block_partition_merge(iter begin, iter end, iter* pivot_positions, Compare less, iter* ret1, iter* ret2) {
+		
+		typedef typename std::iterator_traits<iter>::difference_type index;		
+		index block1[BLOCKSIZE+1], block2[BLOCKSIZE+1];
+		//An index should never become less than 0. 
+		block1[BLOCKSIZE] = INFINITY;
+		block2[BLOCKSIZE] = INFINITY;
+		//index R[block], L[block];
+
+		iter last = end-1;
+		//Moving pivots to the last positions
+		//std::cout << "Pivots: " << *pivot_positions[0] << ", " << *pivot_positions[1] << std::endl;
+		//printArray(begin, end, "Start array");
+		std::iter_swap(pivot_positions[0], last);
+		const typename std::iterator_traits<iter>::value_type & p1 = *last;
+		pivot_positions[0] = last;
+		last--;
+		std::iter_swap(pivot_positions[1], last);
+		const typename std::iterator_traits<iter>::value_type & p2 = *last;
+		pivot_positions[1] = last;
+		last--;
+
+		int num1 = 0;
+		int num2 = 0;
+		int start1 = 0;
+		int start2 = 0;
+		iter counter = begin;
+		iter offset1 = begin;
+		iter offset2 = begin;
+		int num;
+		while (last - counter + 1 > 0) {
+
+			int t = (last-counter+1);
+			int limit = std::min(BLOCKSIZE, t);
+			for (index j = 0; j < limit; j++) {
+					block1[num1] = j;
+					int o = less(counter[j], p1);
+					num1 += o;	
+					block2[num2] = j;
+					num2 += less(counter[j], p2) - o;
+			}
+			
+			//Rearrange the elements
+			//Find the first element we have stored in a block
+			num = num1+num2;
+			//std::cout << "I found elements: " << num << std::endl;
+			start1 += (num1 == 0) * (BLOCKSIZE-start1);
+			start2 += (num2 == 0) * (BLOCKSIZE-start2);
+			for(int k = 0; k < num; k++){
+				if(block1[start1] < block2[start2] ) {
+					rotations::rotate3(*(counter+block1[start1]), *offset2, *offset1);
+					offset1++;
+					offset2++;
+					start1++;
+					num1--;
+					//Move start1 to the end of the array
+					
+					start1 += (num1 == 0) * (BLOCKSIZE-start1);
+				}
+				else{
+					std::iter_swap(offset2, counter+block2[start2]);
+					start2++;
+					offset2++;
+					num2--;
+					start2 += (num2 == 0) * (BLOCKSIZE-start2);
+				}
+			}
+			start1 = 0;
+			start2 = 0;
+			num1 = 0;
+			num2 = 0;
+			counter += limit;
+
+		}
+		rotations::rotate3(*offset2, *offset1, *(end-1));
+		offset2++;
+		std::iter_swap(end-2, offset2);
+		*ret1 = offset1;
+		*ret2 = offset2;
+	}
+
+
+	template<typename iter, typename Compare>
+	inline void dual_lomuto_block_partition_while(iter begin, iter end, iter* pivot_positions, Compare less, iter* ret1, iter* ret2) {
+		typedef typename std::iterator_traits<iter>::difference_type index;		
+		index block1[BLOCKSIZE+1], block2[BLOCKSIZE+1];
+		//An index should never become less than 0. 
+		block1[BLOCKSIZE] = INFINITY;
+		block2[BLOCKSIZE] = INFINITY;
+		//index R[block], L[block];
+
+		iter last = end-1;
+		//Moving pivots to the last positions
+		std::iter_swap(pivot_positions[0], last);
+		const typename std::iterator_traits<iter>::value_type & p1 = *last;
+		pivot_positions[0] = last;
+		last--;
+		std::iter_swap(pivot_positions[1], last);
+		const typename std::iterator_traits<iter>::value_type & p2 = *last;
+		pivot_positions[1] = last;
+		last--;
+
+		int num1 = 0;
+		int num2 = 0;
+		int start1 = 0;
+		int start2 = 0;
+		iter counter = begin;
+		iter offset1 = begin;
+		iter offset2 = begin;
+		int num;
+		while (last - counter + 1 > 0) {
+
+			//Seg fault issue here, look at simple
+			int t = (last-counter+1);
+			int limit = std::min(BLOCKSIZE, t);
+			for (index j = 0; j < limit; j++) {
+					block1[num1] = j;
+					int o = less(counter[j], p1);
+					num1 += o;	
+					block2[num2] = j;
+					num2 += less(counter[j], p2) - o;
+			}
+			//Rearrange the elements
+			//Find the first element we have stored in a block
+			num = num1+num2;
+			int k = 0; 
+			start1 += (num1 == 0) * (BLOCKSIZE-start1);
+			start2 += (num2 == 0) * (BLOCKSIZE-start2);
+			while(k < num){
+
+				//Look into how merge is done properly according to branchless merge sort
+				while(block1[start1] < block2[start2] ){
+					//double check rotations
+					rotations::rotate3(*(counter+block1[start1]), *offset2, *offset1);
+					offset1++;
+					offset2++;
+					start1++;
+					num1--;
+					k++;
+					start1 += (num1 == 0) * (BLOCKSIZE-start1);
+				}
+				while(block2[start2] < block1[start1]){
+					std::iter_swap(offset2, counter+block2[start2]);
+					start2++;
+					offset2++;
+					num2--;
+					k++;
+					start2 += (num2 == 0) * (BLOCKSIZE-start2);
+				}
+
+			}
+			start1 = 0;
+			start2 = 0;
+			num1 = 0;
+			num2 = 0;
+			counter += limit;
+
+		}
+
+		rotations::rotate3(*offset2, *offset1, *(end-1));
+		offset2++;
+		std::iter_swap(end-2, offset2);
+		*ret1 = offset1;
+		*ret2 = offset2;
+	}
+
+
+	template<typename iter, typename Compare>
+	inline void dual_lomuto_block_partition_simple_elements(iter begin, iter end, iter* pivot_positions, Compare less, iter* ret1, iter* ret2) {
+		typedef typename std::iterator_traits<iter>::difference_type index;		
+		typedef typename std::iterator_traits<iter>::value_type val;
+		val block1[BLOCKSIZE];
+		val block2[BLOCKSIZE];
+		val block3[BLOCKSIZE];
+		//index R[block], L[block];
+
+		iter last = end-1;
+		//Moving pivots to the last positions
+		
+		std::iter_swap(pivot_positions[0], last);
+		const typename std::iterator_traits<iter>::value_type & p1 = *last;
+		pivot_positions[0] = last;
+		last--;
+		std::iter_swap(pivot_positions[1], last);
+		const typename std::iterator_traits<iter>::value_type & p2 = *last;
+		pivot_positions[1] = last;
+		last--;
+
+		int num1 = 0;
+		int num2 = 0;
+		int num3 = 0;
+		iter counter = begin;
+		iter offset1 = begin;
+		iter offset2 = begin;
+		while (last - counter + 1 > 0) {
+			int t = (last-counter+1);
+			int limit = std::min(BLOCKSIZE, t);
+			for (index j = 0; j < limit; j++) {
+					//Should be copied and not a reference
+					block1[num1] = *(counter+j);
+					int o = less(counter[j], p1);
+					num1 += o;	
+					block2[num2] = *(counter+j);
+					int s = less(counter[j], p2);
+					num2 +=  s - o;
+					block3[num3] = *(counter+j);
+					num3 += 1 - s;
+			}
+			
+			for(index p = 0; p < num1; p++){
+				*counter = block1[p];
+				rotations::rotate3(*counter, *offset2, *offset1);
+				offset1++;
+				offset2++;
+				counter++;
+			}
+
+			for(index q = 0; q < num2; q++){
+				*counter = block2[q];
+				std::iter_swap(offset2, counter);
+				counter++;
+				offset2++;
+			}
+			for(index p = 0; p < num3; p++){
+				*counter = block3[p];
+				counter++;
+			}
+			num1 = 0;
+			num2 = 0;
+			num3 = 0;
+
+		}
+		
+		rotations::rotate3(*offset2, *offset1, *(end-1));
+		offset2++;
+		std::iter_swap(end-2, offset2);
+		*ret1 = offset1;
+		*ret2 = offset2;
+	}
+
+	template<typename iter, typename Compare>
+	inline void dual_lomuto_block_partition_elements(iter begin, iter end, iter* pivot_positions, Compare less, iter* ret1, iter* ret2) {
+		typedef typename std::iterator_traits<iter>::difference_type index;		
+		typedef typename std::iterator_traits<iter>::value_type val;
+		val block1[BLOCKSIZE];
+		val block2[BLOCKSIZE];
+		val block3[BLOCKSIZE];
+		//index R[block], L[block];
+
+		iter last = end-1;
+		//Moving pivots to the last positions
+		
+		std::iter_swap(pivot_positions[0], last);
+		const typename std::iterator_traits<iter>::value_type & p1 = *last;
+		pivot_positions[0] = last;
+		last--;
+		std::iter_swap(pivot_positions[1], last);
+		const typename std::iterator_traits<iter>::value_type & p2 = *last;
+		pivot_positions[1] = last;
+		last--;
+
+		int num1 = 0;
+		int num2 = 0;
+		int num3 = 0;
+		iter counter = begin;
+		iter offset1 = begin;
+		iter offset2 = begin;
+		while (last - counter + 1 > BLOCKSIZE) {
+			for (index j = 0; j < BLOCKSIZE; j++) {
+					//Should be copied and not a reference
+					block1[num1] = *(counter+j);
+					int o = less(counter[j], p1);
+					num1 += o;	
+					block2[num2] = *(counter+j);
+					int s = less(counter[j], p2);
+					num2 +=  s - o;
+					block3[num3] = *(counter+j);
+					num3 += 1 - s;
+			}
+			
+			for(index p = 0; p < num1; p++){
+				*counter = block1[p];
+				rotations::rotate3(*counter, *offset2, *offset1);
+				offset1++;
+				offset2++;
+				counter++;
+			}
+
+			for(index q = 0; q < num2; q++){
+				*counter = block2[q];
+				std::iter_swap(offset2, counter);
+				counter++;
+				offset2++;
+			}
+			for(index p = 0; p < num3; p++){
+				*counter = block3[p];
+				counter++;
+			}
+			num1 = 0;
+			num2 = 0;
+			num3 = 0;
+
+		}
+		for (index j = 0; j < (last-counter+1); j++) {
+				//Should be copied and not a reference
+				block1[num1] = *(counter+j);
+				int o = less(counter[j], p1);
+				num1 += o;	
+				block2[num2] = *(counter+j);
+				int s = less(counter[j], p2);
+				num2 +=  s - o;
+				block3[num3] = *(counter+j);
+				num3 += 1 - s;
+		}
+		
+		for(index p = 0; p < num1; p++){
+			*counter = block1[p];
+			rotations::rotate3(*counter, *offset2, *offset1);
+			offset1++;
+			offset2++;
+			counter++;
+		}
+
+		for(index q = 0; q < num2; q++){
+			*counter = block2[q];
+			std::iter_swap(offset2, counter);
+			counter++;
+			offset2++;
+		}
+		for(index p = 0; p < num3; p++){
+			*counter = block3[p];
+			counter++;
+		}
+		
+		rotations::rotate3(*offset2, *offset1, *(end-1));
+		offset2++;
+		std::iter_swap(end-2, offset2);
+		*ret1 = offset1;
+		*ret2 = offset2;
+	}
+
+
+
+	//Bulk move has to be rethought, it does not work in the current state of the idea
+	template<typename iter, typename Compare>
+	inline void dual_lomuto_block_partition_simple_elements_move(iter begin, iter end, iter* pivot_positions, Compare less, iter* ret1, iter* ret2) {
+		typedef typename std::iterator_traits<iter>::difference_type index;		
+		typedef typename std::iterator_traits<iter>::value_type val;
+		val block1[BLOCKSIZE];
+		val block2[BLOCKSIZE];
+		val block3[BLOCKSIZE];
+		//index R[block], L[block];
+
+		iter last = end-1;
+		//Moving pivots to the last positions
+		
+		std::iter_swap(pivot_positions[0], last);
+		const typename std::iterator_traits<iter>::value_type & p1 = *last;
+		pivot_positions[0] = last;
+		last--;
+		std::iter_swap(pivot_positions[1], last);
+		const typename std::iterator_traits<iter>::value_type & p2 = *last;
+		pivot_positions[1] = last;
+		last--;
+
+		int num1 = 0;
+		int num2 = 0;
+		int num3 = 0;
+		iter counter = begin;
+		iter offset1 = begin;
+		iter offset2 = begin;
+		while (last - counter + 1 > 0) {
+			int t = (last-counter+1);
+			int limit = std::min(BLOCKSIZE, t);
+			for (index j = 0; j < limit; j++) {
+					//Should be copied and not a reference
+					block1[num1] = *(counter+j);
+					int o = less(counter[j], p1);
+					num1 += o;	
+					block2[num2] = *(counter+j);
+					int s = less(counter[j], p2);
+					num2 +=  s - o;
+					block3[num3] = *(counter+j);
+					num3 += 1 - s;
+			}
+
+			//std::move(block1, block1+num1, counter);
+			for(index p = 0; p < num1; p++){
+				*counter = block1[p];
+				rotations::rotate3(*counter, *offset2, *offset1);
+				offset1++;
+				offset2++;
+				counter++;
+			}
+
+			for(index q = 0; q < num2; q++){
+				*counter = block2[q];
+				std::iter_swap(offset2, counter);
+				counter++;
+				offset2++;
+			}
+			//Should be able to bulk move this
+
+//			std::copy(block3, (block3+num3), counter);
+			//std::memcpy(static_cast<void *>(counter), &block3, sizeof(iter) * num3);std::move
+			std::move(block3, (block3+num3), counter);
+			counter+= num3;
+			/*for(index p = 0; p < num3; p++){
+				*counter = block3[p];
+				counter++;
+			}*/
+			num1 = 0;
+			num2 = 0;
+			num3 = 0;
+
+		}
+		
+		rotations::rotate3(*offset2, *offset1, *(end-1));
+		offset2++;
+		std::iter_swap(end-2, offset2);
+		*ret1 = offset1;
+		*ret2 = offset2;
+	}
+
+	//Multi-Pivot part 
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_tertiles_of_3_pivots_2(begin, end-1, less);
+			dual_lomuto_block_partition_simple(begin, end, pivots, less, p1, p2);
+		}
+	};
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_mo5 {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_tertiles_of_5_pivots_2(begin, end-1, less);
+			dual_lomuto_block_partition_simple(begin, end, pivots, less, p1, p2);
+		}
+	};
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_merge {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_tertiles_of_3_pivots_2(begin, end-1, less);
+			dual_lomuto_block_partition_merge(begin, end, pivots, less, p1, p2);
+		}
+	};		
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_while {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_tertiles_of_3_pivots_2(begin, end-1, less);
+			dual_lomuto_block_partition_while(begin, end, pivots, less, p1, p2);
+		}
+	};	
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_elements {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_tertiles_of_3_pivots_2(begin, end-1, less);
+			dual_lomuto_block_partition_simple_elements(begin, end, pivots, less, p1, p2);
+		}
+	};		
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_elements_optimized {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_third_fifth_element(begin, end-1, less);
+			dual_lomuto_block_partition_elements(begin, end, pivots, less, p1, p2);
+		}
+	};		
+
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_elements_move {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_tertiles_of_3_pivots_2(begin, end-1, less);
+			dual_lomuto_block_partition_simple_elements_move(begin, end, pivots, less, p1, p2);
+		}
+	};
+
+	//Three different pivot selection strategies
+
+	//Third and fifth
+	//*******************************************
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_third_fifth {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_third_fifth_element(begin, end-1, less);
+			dual_lomuto_block_partition_simple(begin, end, pivots, less, p1, p2);
+		}
+	};
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_merge_third_fifth {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_third_fifth_element(begin, end-1, less);
+			dual_lomuto_block_partition_merge(begin, end, pivots, less, p1, p2);
+		}
+	};		
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_while_third_fifth {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_third_fifth_element(begin, end-1, less);
+			dual_lomuto_block_partition_while(begin, end, pivots, less, p1, p2);
+		}
+	};	
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_elements_third_fifth {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_third_fifth_element(begin, end-1, less);
+			dual_lomuto_block_partition_simple_elements(begin, end, pivots, less, p1, p2);
+		}
+	};		
+
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_elements_move_third_fifth {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_third_fifth_element(begin, end-1, less);
+			dual_lomuto_block_partition_simple_elements_move(begin, end, pivots, less, p1, p2);
+		}
+	};
+
+
+	//Second and forth
+	//*******************************************
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_second_forth {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_second_forth_element(begin, end-1, less);
+			dual_lomuto_block_partition_simple(begin, end, pivots, less, p1, p2);
+		}
+	};
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_merge_second_forth {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_second_forth_element(begin, end-1, less);
+			dual_lomuto_block_partition_merge(begin, end, pivots, less, p1, p2);
+		}
+	};		
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_while_second_forth {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_second_forth_element(begin, end-1, less);
+			dual_lomuto_block_partition_while(begin, end, pivots, less, p1, p2);
+		}
+	};	
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_elements_second_forth {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_second_forth_element(begin, end-1, less);
+			dual_lomuto_block_partition_simple_elements(begin, end, pivots, less, p1, p2);
+		}
+	};		
+
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_elements_move_second_forth {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_second_forth_element(begin, end-1, less);
+			dual_lomuto_block_partition_simple_elements_move(begin, end, pivots, less, p1, p2);
+		}
+	};
+
+	//First and forth
+	//*******************************************
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_first_forth {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_first_forth_element(begin, end-1, less);
+			dual_lomuto_block_partition_simple(begin, end, pivots, less, p1, p2);
+		}
+	};
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_merge_first_forth {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_first_forth_element(begin, end-1, less);
+			dual_lomuto_block_partition_merge(begin, end, pivots, less, p1, p2);
+		}
+	};		
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_while_first_forth {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_first_forth_element(begin, end-1, less);
+			dual_lomuto_block_partition_while(begin, end, pivots, less, p1, p2);
+		}
+	};	
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_elements_first_forth {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_first_forth_element(begin, end-1, less);
+			dual_lomuto_block_partition_simple_elements(begin, end, pivots, less, p1, p2);
+		}
+	};		
+
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_elements_move_first_forth {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_first_forth_element(begin, end-1, less);
+			dual_lomuto_block_partition_simple_elements_move(begin, end, pivots, less, p1, p2);
+		}
+	};
+
+	//First and seventh
+	//*******************************************
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_first_seventh {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_first_seventh_element(begin, end-1, less);
+			dual_lomuto_block_partition_simple(begin, end, pivots, less, p1, p2);
+		}
+	};
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_merge_first_seventh {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_first_seventh_element(begin, end-1, less);
+			dual_lomuto_block_partition_merge(begin, end, pivots, less, p1, p2);
+		}
+	};		
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_while_first_seventh {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_first_seventh_element(begin, end-1, less);
+			dual_lomuto_block_partition_while(begin, end, pivots, less, p1, p2);
+		}
+	};	
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_elements_first_seventh {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_first_seventh_element(begin, end-1, less);
+			dual_lomuto_block_partition_simple_elements(begin, end, pivots, less, p1, p2);
+		}
+	};		
+
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_elements_move_first_seventh {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_first_seventh_element(begin, end-1, less);
+			dual_lomuto_block_partition_simple_elements_move(begin, end, pivots, less, p1, p2);
+		}
+	};
+
+template<typename iter, typename Compare>
+inline void lomuto_2_partition(iter begin, iter end, iter* pivot_positions, Compare less,iter* ret1, iter* ret2){
+	typedef typename std::iterator_traits<iter>::difference_type index;
+	typedef typename std::iterator_traits<iter>::value_type val;
+	val block1[BLOCKSIZE];
+	int num1 = 0;
+	val block2[BLOCKSIZE];
+	int num2 = 0;
+	val block3[BLOCKSIZE];
+	int num3 = 0;
+	iter last = end-1;
+	std::iter_swap(pivot_positions[0], last);
+	const typename std::iterator_traits<iter>::value_type & p1 = *last;
+	pivot_positions[0] = last;
+	last--;
+	iter offset1 = begin;
+	std::iter_swap(pivot_positions[1], last);
+	const typename std::iterator_traits<iter>::value_type & p2 = *last;
+	pivot_positions[1] = last;
+	last--;
+	iter offset2 = begin;
+	iter counter = begin;
+	while (last - counter + 1 > BLOCKSIZE) {
+		for(index j = 0;j < BLOCKSIZE; j++) {
+			block1[num1] = *(counter+j);
+			int o1 = less(counter[j], p1);
+			num1+= o1;
+			block2[num2] = *(counter+j);
+			int o2 = less(counter[j], p2);
+			num2 += o2 - o1;
+			block3[num3] = *(counter+j);
+			num3 += 1 - o2;
+		}
+		for(index p = 0; p < num1; p++){
+			*counter = block1[p];
+			rotations::rotate3(*counter, *offset2, *offset1);
+			offset2++;
+			offset1++;
+			counter++;
+		}
+		num1 = 0;
+		for(index p = 0; p < num2; p++){
+			*counter = block2[p];
+			std::iter_swap(offset2, counter);
+			offset2++;
+			counter++;
+		}
+		num2 = 0;
+		for(index p = 0; p < num3; p++){
+			*counter = block3[p];
+			counter++;
+		}
+		num3 = 0;
+	}
+		for(index j = 0;j < (last-counter+1); j++) {
+			block1[num1] = *(counter+j);
+			int o1 = less(counter[j], p1);
+			num1+= o1;
+			block2[num2] = *(counter+j);
+			int o2 = less(counter[j], p2);
+			num2 += o2 - o1;
+			block3[num3] = *(counter+j);
+			num3 += 1 - o2;
+		}
+		for(index p = 0; p < num1; p++){
+			*counter = block1[p];
+			rotations::rotate3(*counter, *offset2, *offset1);
+			offset2++;
+			offset1++;
+			counter++;
+		}
+		for(index p = 0; p < num2; p++){
+			*counter = block2[p];
+			std::iter_swap(offset2, counter);
+			offset2++;
+			counter++;
+		}
+		for(index p = 0; p < num3; p++){
+			*counter = block3[p];
+			counter++;
+		}
+	rotations::rotate3(*offset2, *offset1,  *(end-1));
+	offset2++;
+	std::iter_swap(end-2, offset2);
+	*ret1 = offset1;
+	*ret2 = offset2;
+}
+
+	template< typename iter, typename Compare>
+	struct Dual_Lomuto_Block_partition_elements_generated_test {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_first_seventh_element(begin, end-1, less);
+			lomuto_2_partition(begin, end, pivots, less, p1, p2);
+		}
+	};
+
+	//Multi-Pivot part 
+	template< typename iter, typename Compare>
+	struct Dual_Pivot_Inline_Hoare_Block_partition_simple {
+		static inline void partition(iter begin, iter end, iter* p1, iter* p2, Compare less) {
+			iter* pivots = median::mp_tertiles_of_3_pivots_2(begin, end-1, less);
+			dual_pivot_inline_block_partition_simple(begin, end, pivots, less, p1, p2);
+		}
+	};
 };

--- a/quicksort.h
+++ b/quicksort.h
@@ -5,7 +5,7 @@
 *
 ******************************************************************************
 * Copyright (C) 2016 Stefan Edelkamp <edelkamp@tzi.de>
-* Copyright (C) 2016 Armin Weiß <armin.weiss@fmi.uni-stuttgart.de>
+* Copyright (C) 2016 Armin Weiï¿½ <armin.weiss@fmi.uni-stuttgart.de>
 *
 * This program is free software: you can redistribute it and/or modify it
 * under the terms of the GNU General Public License as published by the Free
@@ -25,9 +25,12 @@
 #include <future>
 #include <cstdlib>
 #ifndef IS_THRESH
-#define IS_THRESH (1<<4)
+#define IS_THRESH (1 << 4)
 #endif // !IS_THRESH
-
+#if defined(PAPI)
+#include <papi.h>
+#define NUM_EVENTS 4//8//4//8//12
+#endif
 
 namespace quicksort {
 
@@ -119,7 +122,46 @@ namespace quicksort {
 	//available at http://www.diku.dk/~jyrki/Myris/Kat2014S.html
 	template<template<class , class> class Partitioner, typename iter, typename Compare>
 	inline void qsort(iter begin, iter end, Compare less) {
+			#if defined(PAPI)
+			
+			
+			/* Start counting events */
+			
+			int event[NUM_EVENTS] = {
+									/*	PAPI_BR_CN,	 
+										PAPI_BR_INS,	
+										PAPI_BR_MSP,   	
+										PAPI_BR_NTK,
+										PAPI_BR_PRC,
+										PAPI_BR_TKN,
+										PAPI_BR_UCN,
+										PAPI_TOT_INS*/
+										PAPI_L1_TCM,	
+										PAPI_L2_TCM,	
+									//	PAPI_L3_TCM,	
+										PAPI_TOT_CYC,	
+										PAPI_TOT_INS
+										//PAPI_L1_TCM,
+										//PAPI_L2_TCM,
+										//PAPI_L3_TCM,
+										//PAPI_TOT_CYC,
+										//PAPI_TOT_INS
+									};
+			long long values[NUM_EVENTS];
+
+			/* Start counting events */
+			if (PAPI_start_counters(event, NUM_EVENTS) != PAPI_OK) {
+				fprintf(stderr, "PAPI_start_counters - FAILED\n");
+				exit(1);
+			}
+			//handle_error(1);
+			
+			/* Do some computation here*/
+			
+		#endif
+
 		const int depth_limit = 2 * ilogb((double)(end - begin)) + 3;
+	//	std::cout << "Running" << std::endl;
 		iter stack[80];
 		iter* s = stack;
 		int depth_stack[40];
@@ -131,15 +173,28 @@ namespace quicksort {
 		*d_s_top = 0;
 		++d_s_top;
 		do {
-			if (depth < depth_limit && end - begin > IS_THRESH) {
+		/*	std::cout << "in loop" << std::endl;
+			std::cout << "depth: " << depth << std::endl;
+			std::cout << "depth < depth_limit: " << (depth < depth_limit) << std::endl;
+			std::cout << "end: " << *end << " begin: " << *begin << std::endl;
+			std::cout << "end-begin: " << end-begin << " is_thresh: " << IS_THRESH << std::endl;
+			
+			std::cout << "end-begin > IS_THRESH: " << (end - begin > IS_THRESH) << std::endl;
+			*/
+			if (depth < depth_limit && (end - begin > IS_THRESH)) {
+			//	std::cout << "Inside if" << std::endl;
+
 				iter pivot;
 				pivot = Partitioner< iter, Compare>::partition(begin, end, less);
+			//	std::cout << "pivot - begin " << (pivot - begin) << std::endl; 
 				if (pivot - begin > end - pivot) {
 					*s = begin;
 					*(s + 1) = pivot;
 					begin = pivot + 1;
+				//	std::cout << "Added begin" << std::endl;
 				}
 				else {
+				//	std::cout << "added end" << std::endl;
 					*s = pivot + 1;
 					*(s + 1) = end;
 					end = pivot;
@@ -168,6 +223,704 @@ namespace quicksort {
 				depth = *d_s_top;
 			}
 		} while (s != stack);
+		
+		#if defined(PAPI)
+		/* Stop counting events */
+			/*if (PAPI_stop_counters(values, 14) != PAPI_OK){
+				std::cout << "SOmething went wrong" << std::endl;
+			}*/
+			 if (PAPI_stop_counters(values, NUM_EVENTS) != PAPI_OK) {
+				fprintf(stderr, "PAPI_stoped_counters - FAILED\n");
+				exit(1);
+			}
+			
+			/*std::cout << "Conditional branch instructions: " << values[0] << std::endl;
+			std::cout << "Branch instructions: " << values[1] << std::endl;
+			std::cout << "Conditional branch instructions mispredicted: " << values[2] << std::endl;	
+			std::cout << "Conditional branch instructions not taken: " << values[3] << std::endl;
+			std::cout << "Conditional branch instructions correctly predicted: " << values[4] << std::endl;		
+			std::cout << "Unconditional branch instructions: " << values[6] << std::endl;	
+			std::cout << "Instructions completed: " << values[7] << std::endl;
+			*/
+			
+			std::cout << "Level 1 cache misses: " << values[0] << std::endl;
+			std::cout << "Level 2 cache misses: " << values[1] << std::endl;
+			std::cout << "Total cycles: " << values[2] << std::endl;
+			std::cout << "Instructions completed: " << values[3] << std::endl;	
+			
+					
+		#endif
 	}
+
+	//main Multi-Pivot Quicksort loop NOT supporting Partitioner with check for duplicate elements
+	//Implementation based on Tuned Quicksort (Elmasry, Katajainen, Stenmark)
+	//available at http://www.diku.dk/~jyrki/Myris/Kat2014S.html
+	
+	template<template<class , class> class Partitioner, typename iter, typename Compare>
+	inline void qsort_dual_pivot(iter begin, iter end, Compare less) {
+
+
+		#if defined(PAPI)
+			
+			
+			/* Start counting events */
+			
+			int event[NUM_EVENTS] = {
+										PAPI_L1_TCM,	
+										PAPI_L2_TCM,	
+									//	PAPI_L3_TCM,	
+										PAPI_TOT_CYC,	
+										PAPI_TOT_INS
+										/*PAPI_BR_CN,	 
+										PAPI_BR_INS,	
+										PAPI_BR_MSP,   	
+										PAPI_BR_NTK,
+										PAPI_BR_PRC,
+										PAPI_BR_TKN,
+										PAPI_BR_UCN,
+										PAPI_TOT_INS*/
+										//PAPI_L1_TCM,
+										//PAPI_L2_TCM,
+										//PAPI_L3_TCM,
+										//PAPI_TOT_CYC,
+										//PAPI_TOT_INS
+									};
+			long long values[NUM_EVENTS];
+
+			/* Start counting events */
+			if (PAPI_start_counters(event, NUM_EVENTS) != PAPI_OK) {
+				fprintf(stderr, "PAPI_start_counters - FAILED\n");
+				exit(1);
+			}
+			//handle_error(1);
+			
+			/* Do some computation here*/
+			
+		#endif
+
+		const int depth_limit = 2 * ilogb((double)(end - begin)) + 3;
+		iter stack[80];
+		iter* s = stack;
+		int depth_stack[80];
+		int depth = 0;
+		int* d_s_top = depth_stack;
+		*s = begin;
+		*(s + 1) = end;
+		s += 2;
+		*d_s_top = 0;
+		++d_s_top;
+		do {
+			assert((end >= begin));
+			if (depth < depth_limit && (end - begin > IS_THRESH)) {
+				iter p1;
+				iter p2;
+				
+				Partitioner<iter, Compare>::partition(begin, end, &p1, &p2, less);
+				
+				assert((p1 < p2));
+				assert(p2 < end);
+				int part1 = p1 - begin;
+				int part2 = p2 - p1;
+				int part3 = end - p2;
+				if (part2 > part1 && part3 > part1) { //Partition 1 is the smallest
+					*s = p1 + 1;
+					*(s + 1) = p2;
+					*(s + 2) = p2 + 1;
+					*(s + 3) = end;
+					end = p1;
+				}
+				else if(part1 > part2 && part3 > part2) { //Partition 2 is the smallest
+					*s = begin;
+					*(s + 1) = p1;
+					*(s + 2) = p2 + 1;
+					*(s + 3) = end;
+					begin = p1 + 1;
+					end = p2;
+				}
+				else {
+					*s = begin;
+					*(s + 1) = p1;
+					*(s + 2) = p1 + 1;
+					*(s + 3) = p2;
+					begin = p2 + 1;
+				}
+				assert(begin <= end);
+				s += 4;
+				*d_s_top = ++depth;
+				*(d_s_top+1) = ++depth;
+				d_s_top += 2;
+
+			}
+			else {
+				
+				if (end - begin > IS_THRESH) { // if recursion depth limit exceeded
+#ifdef PARTIAL_SORT_COUNT
+					partial_sort_count++;
+#endif
+					std::partial_sort(begin, end, end);
+				}
+#ifndef NOINSERTIONSORT
+				else {
+					insertionsort::insertion_sort(begin, end, less); // copy of std::__insertion_sort (GCC 4.7.2)
+				}
+#endif 			
+				//pop new subarray from stack
+				s -= 2;
+				begin = *s;
+				end = *(s + 1);
+				--d_s_top;
+				assert(d_s_top != (depth_stack-1));
+				depth = *d_s_top;
+				assert(begin <= end);
+			}
+		} while (s != stack);
+		#if defined(PAPI)
+		/* Stop counting events */
+			/*if (PAPI_stop_counters(values, 14) != PAPI_OK){
+				std::cout << "SOmething went wrong" << std::endl;
+			}*/
+			 if (PAPI_stop_counters(values, NUM_EVENTS) != PAPI_OK) {
+				fprintf(stderr, "PAPI_stoped_counters - FAILED\n");
+				exit(1);
+			}
+			
+
+
+			/*std::cout << "Conditional branch instructions: " << values[0] << std::endl;
+
+			std::cout << "Branch instructions: " << values[1] << std::endl;
+
+			std::cout << "Conditional branch instructions mispredicted: " << values[2] << std::endl;	
+			std::cout << "Conditional branch instructions not taken: " << values[3] << std::endl;
+
+			std::cout << "Conditional branch instructions correctly predicted: " << values[4] << std::endl;		
+
+			std::cout << "Unconditional branch instructions: " << values[6] << std::endl;	
+
+
+			std::cout << "Instructions completed: " << values[7] << std::endl;
+			*/
+
+			std::cout << "Level 1 cache misses: " << values[0] << std::endl;
+			std::cout << "Level 2 cache misses: " << values[1] << std::endl;
+			//std::cout << "Level 3 cache misses: " << values[2] << std::endl;	
+			std::cout << "Total cycles: " << values[2] << std::endl;
+			std::cout << "Instructions completed: " << values[3] << std::endl;	
+					
+		#endif
+	}
+
+
+	template<template<class , class> class Partitioner, typename iter, typename Compare>
+	inline void qsort_dual_pivot_equal_elements(iter begin, iter end, Compare less) {
+		const int depth_limit = 2 * ilogb((double)(end - begin)) + 3;
+		iter stack[80];
+		iter* s = stack;
+		int depth_stack[80];
+		int depth = 0;
+		int* d_s_top = depth_stack;
+		*s = begin;
+		*(s + 1) = end;
+		s += 2;
+		*d_s_top = 0;
+		++d_s_top;
+		do {
+			assert((end >= begin));
+			if (depth < depth_limit && (end - begin > IS_THRESH)) {
+				iter p1;
+				iter p2;
+				
+				Partitioner<iter, Compare>::partition(begin, end, &p1, &p2, less);
+				
+				if(*p1 == *p2){
+					//Disregard the middle partition
+					//search, we remove all the elements equal to the pivot
+					int part1 = p1 - begin;
+					//int part2 = p2 - p1;
+					int part3 = end - p2;
+					if (part1 > part3) {
+						*s = begin;
+						*(s + 1) = p1;
+						begin = p2 + 1;
+					}
+					else {
+						*s = p2 + 1; 
+						*(s + 1) = end;
+						end = p1;
+					}
+
+					s += 2;
+					depth++;
+					*d_s_top = depth;
+					++d_s_top;
+
+				}
+				else{
+					//Attempt at making things smaller
+					//Search, we remove all the elements equal to the pivot
+					iter tmp2 = p2;
+					while(*p2 == *(tmp2-1) && less(*p1, *(tmp2-1))) 
+						tmp2--;
+
+					//Search in the middle
+					iter tmp1 = p1;
+					while(*p1 == *(tmp1+1) && less(*(tmp1+1), *end))
+						tmp1++;
+					
+					int part1 = p1 - begin;
+					int part2 = tmp2 - tmp1;
+					int part3 = end - p2;
+
+					if (part2 > part1 && part3 > part1) { //Partition 1 is the smallest
+						*s = tmp1 + 1;
+						*(s + 1) = tmp2;
+						*(s + 2) = p2 + 1;
+						*(s + 3) = end;
+						end = p1;
+					}
+					else if(part1 > part2 && part3 > part2) { //Partition 2 is the smallest
+						*s = begin;
+						*(s + 1) = p1;
+						*(s + 2) = p2 + 1;
+						*(s + 3) = end;
+						begin = tmp1 + 1;
+						end = tmp2;
+					}
+					else {
+						*s = begin;
+						*(s + 1) = p1;
+						*(s + 2) = tmp1 + 1;
+						*(s + 3) = tmp2;
+						begin = p2 + 1;
+					}
+					assert(begin <= end);
+					s += 4;
+					*d_s_top = ++depth;
+					*(d_s_top+1) = ++depth;
+					d_s_top += 2;
+				}
+				
+
+			}
+			else {
+				
+				if (end - begin > IS_THRESH) { // if recursion depth limit exceeded
+#ifdef PARTIAL_SORT_COUNT
+					partial_sort_count++;
+#endif
+					std::partial_sort(begin, end, end);
+				}
+#ifndef NOINSERTIONSORT
+				else {
+					insertionsort::insertion_sort(begin, end, less); // copy of std::__insertion_sort (GCC 4.7.2)
+				}
+#endif 			
+				//pop new subarray from stack
+				s -= 2;
+				begin = *s;
+				end = *(s + 1);
+				--d_s_top;
+				assert(d_s_top != (depth_stack-1));
+				depth = *d_s_top;
+				assert(begin <= end);
+			}
+		} while (s != stack);
+	}
+
+
+	//main Multi-Pivot Quicksort loop NOT supporting Partitioner with check for duplicate elements
+	//Implementation based on Tuned Quicksort (Elmasry, Katajainen, Stenmark)
+	//available at http://www.diku.dk/~jyrki/Myris/Kat2014S.html
+	template<template<class , class> class Partitioner, typename iter, typename Compare>
+	inline void qsort_dual_pivot_thousand(iter begin, iter end, Compare less) {
+		const int depth_limit = 2 * ilogb((double)(end - begin)) + 3;
+		iter stack[80];
+		iter* s = stack;
+		int depth_stack[80];
+		int depth = 0;
+		int* d_s_top = depth_stack;
+		*s = begin;
+		*(s + 1) = end;
+		s += 2;
+		*d_s_top = 0;
+		++d_s_top;
+		do {
+			assert((end >= begin));
+			if (depth < depth_limit && (end - begin > 1000)) {
+				iter p1;
+				iter p2;
+				
+				Partitioner<iter, Compare>::partition(begin, end, &p1, &p2, less);
+				
+				assert((p1 < p2));
+				assert(p2 < end);
+				int part1 = p1 - begin;
+				int part2 = p2 - p1;
+				int part3 = end - p2;
+				if (part2 > part1 && part3 > part1) { //Partition 1 is the smallest
+					*s = p1 + 1;
+					*(s + 1) = p2;
+					*(s + 2) = p2 + 1;
+					*(s + 3) = end;
+					end = p1;
+				}
+				else if(part1 > part2 && part3 > part2) { //Partition 2 is the smallest
+					*s = begin;
+					*(s + 1) = p1;
+					*(s + 2) = p2 + 1;
+					*(s + 3) = end;
+					begin = p1 + 1;
+					end = p2;
+				}
+				else {
+					*s = begin;
+					*(s + 1) = p1;
+					*(s + 2) = p1 + 1;
+					*(s + 3) = p2;
+					begin = p2 + 1;
+				}
+				assert(begin <= end);
+				s += 4;
+				*d_s_top = ++depth;
+				*(d_s_top+1) = ++depth;
+				d_s_top += 2;
+
+			}
+			else {
+				
+				if (end - begin > 1000) { // if recursion depth limit exceeded
+#ifdef PARTIAL_SORT_COUNT
+					partial_sort_count++;
+#endif
+					std::partial_sort(begin, end, end);
+				}
+#ifndef NOINSERTIONSORT
+				else {
+					quicksort::qsort<partition::Hoare_block_partition_mosqrt>(begin, end, less);
+				}
+#endif 			
+				//pop new subarray from stack
+				s -= 2;
+				begin = *s;
+				end = *(s + 1);
+				--d_s_top;
+				assert(d_s_top != (depth_stack-1));
+				depth = *d_s_top;
+				assert(begin <= end);
+			}
+		} while (s != stack);
+	}
+
+
+	template<template<class , class> class Partitioner, typename iter, typename Compare>
+	inline void qsort_dual_pivot_equal_elements_thousand(iter begin, iter end, Compare less) {
+		const int depth_limit = 2 * ilogb((double)(end - begin)) + 3;
+		iter stack[80];
+		iter* s = stack;
+		int depth_stack[80];
+		int depth = 0;
+		int* d_s_top = depth_stack;
+		*s = begin;
+		*(s + 1) = end;
+		s += 2;
+		*d_s_top = 0;
+		++d_s_top;
+		do {
+			assert((end >= begin));
+			if (depth < depth_limit && (end - begin > 1000)) {
+				iter p1;
+				iter p2;
+				
+				Partitioner<iter, Compare>::partition(begin, end, &p1, &p2, less);
+				
+				if(*p1 == *p2){
+					//Disregard the middle partition
+					int part1 = p1 - begin;
+					int part3 = end - p2;
+					if (part1 > part3) {
+						*s = begin;
+						*(s + 1) = p1;
+						begin = p2 + 1;
+					}
+					else {
+						*s = p2 + 1; 
+						*(s + 1) = end;
+						end = p1;
+					}
+
+					s += 2;
+					depth++;
+					*d_s_top = depth;
+					++d_s_top;
+
+				}
+				else{
+					//Attempt at making things smaller
+					//Search, we remove all the elements equal to the pivot
+					iter tmp2 = p2;
+					while(*p2 == *(tmp2-1) && less(*p1, *(tmp2-1))) 
+						tmp2--;
+
+					//Search in the middle
+					iter tmp1 = p1;
+					while(*p1 == *(tmp1+1) && less(*(tmp1+1), *end))
+						tmp1++;
+					
+					int part1 = p1 - begin;
+					int part2 = tmp2 - tmp1;
+					int part3 = end - p2;
+
+					if (part2 > part1 && part3 > part1) { //Partition 1 is the smallest
+						*s = tmp1 + 1;
+						*(s + 1) = tmp2;
+						*(s + 2) = p2 + 1;
+						*(s + 3) = end;
+						end = p1;
+					}
+					else if(part1 > part2 && part3 > part2) { //Partition 2 is the smallest
+						*s = begin;
+						*(s + 1) = p1;
+						*(s + 2) = p2 + 1;
+						*(s + 3) = end;
+						begin = tmp1 + 1;
+						end = tmp2;
+					}
+					else {
+						*s = begin;
+						*(s + 1) = p1;
+						*(s + 2) = tmp1 + 1;
+						*(s + 3) = tmp2;
+						begin = p2 + 1;
+					}
+					assert(begin <= end);
+					s += 4;
+					*d_s_top = ++depth;
+					*(d_s_top+1) = ++depth;
+					d_s_top += 2;
+				}
+				
+
+			}
+			else {
+				
+				if (end - begin > 1000) { // if recursion depth limit exceeded
+#ifdef PARTIAL_SORT_COUNT
+					partial_sort_count++;
+#endif
+					std::partial_sort(begin, end, end);
+				}
+#ifndef NOINSERTIONSORT
+				else {
+					quicksort::qsort<partition::Hoare_block_partition_mosqrt>(begin, end, less);
+				}
+#endif 			
+				//pop new subarray from stack
+				s -= 2;
+				begin = *s;
+				end = *(s + 1);
+				--d_s_top;
+				assert(d_s_top != (depth_stack-1));
+				depth = *d_s_top;
+				assert(begin <= end);
+			}
+		} while (s != stack);
+	}
+
+/*
+	template<template<class , class> class Partitioner, typename iter, typename Compare>
+	inline void qsort_triple_pivot_equal_elements(iter begin, iter end, Compare less) {
+		const int depth_limit = 2 * ilogb((double)(end - begin)) + 3;
+		iter stack[80];
+		iter* s = stack;
+		int depth_stack[80];
+		int depth = 0;
+		int* d_s_top = depth_stack;
+		*s = begin;
+		*(s + 1) = end;
+		s += 2;
+		*d_s_top = 0;
+		++d_s_top;
+		do {
+			assert((end >= begin));
+			if (depth < depth_limit && (end - begin > IS_THRESH)) {
+				iter p1;
+				iter p2;
+				iter p3;
+				
+				Partitioner<iter, Compare>::partition(begin, end, &p1, &p2, &p3, less);
+				if(*p1 == *p3)// everything is equal, disregard everything but first and last partition
+				{
+					int part1 = p1-begin;
+					int part4 = end - p3;
+
+					if(part1 > part4){
+						s* = begin;
+						*(s+1) = p1;
+						begin = p3 + 1;
+					}
+					else{
+						
+					}
+				}
+
+
+				if(*p1 == *p2){
+					//Disregard the middle partition
+					//search, we remove all the elements equal to the pivot
+					int part1 = p1 - begin;
+					//int part2 = p2 - p1;
+					int part3 = end - p2;
+					if (part1 > part3) {
+						*s = begin;
+						*(s + 1) = p1;
+						begin = p2 + 1;
+					}
+					else {
+						*s = p2 + 1; 
+						*(s + 1) = end;
+						end = p1;
+					}
+
+					s += 2;
+					depth++;
+					*d_s_top = depth;
+					++d_s_top;
+
+				}
+				else{
+					//Attempt at making things smaller
+					//Search, we remove all the elements equal to the pivot
+					iter tmp2 = p2;
+					while(*p2 == *(tmp2-1) && less(*p1, *(tmp2-1))) 
+						tmp2--;
+
+					//Search in the middle
+					iter tmp1 = p1;
+					while(*p1 == *(tmp1+1) && less(*(tmp1+1), *end))
+						tmp1++;
+					
+					int part1 = p1 - begin;
+					int part2 = tmp2 - tmp1;
+					int part3 = end - p2;
+
+					if (part2 > part1 && part3 > part1) { //Partition 1 is the smallest
+						*s = tmp1 + 1;
+						*(s + 1) = tmp2;
+						*(s + 2) = p2 + 1;
+						*(s + 3) = end;
+						end = p1;
+					}
+					else if(part1 > part2 && part3 > part2) { //Partition 2 is the smallest
+						*s = begin;
+						*(s + 1) = p1;
+						*(s + 2) = p2 + 1;
+						*(s + 3) = end;
+						begin = tmp1 + 1;
+						end = tmp2;
+					}
+					else {
+						*s = begin;
+						*(s + 1) = p1;
+						*(s + 2) = tmp1 + 1;
+						*(s + 3) = tmp2;
+						begin = p2 + 1;
+					}
+					assert(begin <= end);
+					s += 4;
+					*d_s_top = ++depth;
+					*(d_s_top+1) = ++depth;
+					d_s_top += 2;
+				}
+				
+
+			}
+			else {
+				
+				if (end - begin > IS_THRESH) { // if recursion depth limit exceeded
+#ifdef PARTIAL_SORT_COUNT
+					partial_sort_count++;
+#endif
+					std::partial_sort(begin, end, end);
+				}
+#ifndef NOINSERTIONSORT
+				else {
+					insertionsort::insertion_sort(begin, end, less); // copy of std::__insertion_sort (GCC 4.7.2)
+				}
+#endif 			
+				//pop new subarray from stack
+				s -= 2;
+				begin = *s;
+				end = *(s + 1);
+				--d_s_top;
+				assert(d_s_top != (depth_stack-1));
+				depth = *d_s_top;
+				assert(begin <= end);
+			}
+		} while (s != stack);
+	}*/
+
+template<template<class , class> class Partitioner, typename iter, typename Compare>
+inline void qsort_2_pivot(iter begin, iter end, Compare less) { 
+	const int depth_limit = 2 * ilogb((double)(end - begin)) + 3;
+	iter stack[80];
+	iter* s = stack;
+	int depth_stack[80];
+	int depth = 0;
+	int* d_s_top = depth_stack;
+	*s = begin;
+	*(s + 1) = end;
+	s += 2;
+	*d_s_top = 0;
+	++d_s_top;
+	do {
+		if (depth < depth_limit && (end - begin > 20)) {
+			iter p1;
+			iter p2;
+			Partitioner<iter, Compare>::partition(begin, end,&p1, &p2, less);
+			int part1 = p1 - begin;
+			int part2 = p2 - p1;
+			int part3 = end - p2;
+			if(part2 > part1 && part3 > part1 ) {
+				*s = p1 + 1;
+				*(s+1) = p2;
+				*(s+2) = p2+1;
+				*(s+3) = end;
+				end = p1;
+			}
+			else if(part1 > part2 && part3 > part2 ) {
+				*s = begin;
+				*(s+1) = p1;
+				*(s+2) = p2+1;
+				*(s+3) = end;
+				begin = p1+1;
+				end = p2;
+			}
+			else {
+				*s = begin;
+				*(s+1) = p1;
+				*(s+2) = p1+1;
+				*(s+3) = p2;
+				begin = p2+1;
+			}
+			s += 4;
+			*d_s_top = ++depth;
+			*(d_s_top+1) = ++depth;
+			d_s_top += 2;
+		}
+		else {
+			if(end-begin > 20) { 
+				std::partial_sort(begin, end, end);
+			}
+			else
+				insertionsort::insertion_sort(begin, end, less);
+			s -= 2;
+			begin = *s;
+			end = *(s + 1);
+			--d_s_top;
+			depth = *d_s_top;
+		}
+	} while (s != stack);
+}
+
 
 }


### PR DESCRIPTION
This pull-request contains the work done when conducting in the thesis:
"Design and experimental evaluation of Multi-Pivot BlockQuickSort on Lomuto based partitioning"
Done in collaboration with Martin Aumüller. 

Quite a few different algorithms are included in this pull-request, including:

- Single pivot Lomuto BlockQuickSort
- 4 variants of Dual-Pivot BlockQuickSort
- Many different pivot selection strategy implementation using the "elements in blocks" variant of Dual-Pivot BlockQuickSort

The generator build in Python during the thesis has been included in a different pull-request, to keep things simple and I do not know if the generator fits into the BlockQuickSort repo. 
 
