### PR TITLE
Guard variable partial_sort_count with define

### DIFF
--- a/quicksort.h
+++ b/quicksort.h
@@ -48,7 +48,9 @@ namespace quicksort {
 		{
 			if (depth_limit == 0)
 			{
-				partial_sort_count++;
+#ifdef PARTIAL_SORT_COUNT
+			        partial_sort_count++;
+#endif
 				std::partial_sort(first, last, last, comp);
 				return;
 			}


### PR DESCRIPTION
The variable partial_sort_count is defined in you test file (incl. main()). You missed to guard this line of code (other occurrences are already guarded).

Best